### PR TITLE
Add POS skeleton using Mishkah regions

### DIFF
--- a/pos-comp.js
+++ b/pos-comp.js
@@ -1,0 +1,304 @@
+(function(w){
+  "use strict";
+  const M = w.Mishkah; if(!M||!M.Comp||!M.Atoms){ console.error("Mishkah Comp/Atoms required"); return }
+  const { Comp, Atoms:A } = M;
+
+  // =============== 1) Base Molecules (reusable) ===============
+  // Button
+  if(!Comp.mole.Button){
+    Comp.mole.define("Button", (A, s, app, p)=> A.Button({
+      ...p,
+      tw: (p.tw||"") + " btn " + (p.variant==="ghost"?"btn-ghost":"btn-primary")
+    }, { default: [p.text||"زر"] }));
+  }
+
+  // Badge/Chip
+  if(!Comp.mole.Badge){
+    Comp.mole.define("Badge", (A, s, app, p)=> A.Span({
+      ...p,
+      tw: (p.tw||"") + " chip text-sm"
+    }, { default: [p.text||"●"] }));
+  }
+
+  // DescriptionList
+  if(!Comp.mole.DescriptionList){
+    Comp.mole.define("DescriptionList", (A, s, app, p)=>{
+      const items = p.items||[];
+      return A.Dl({ tw:"space-y-2" }, { default: items.flatMap(it=>[
+        A.Div({ tw:"flex items-center justify-between text-sm" },{
+          default:[ A.Dt({ tw:"text-slate-400" },{default:[it.term||""]}), A.Dd({ tw:"font-semibold" },{default:[it.details||""]}) ]
+        })
+      ])})
+    });
+  }
+
+  // Segmented Control (Tabs)
+  if(!Comp.mole.Segmented){
+    Comp.mole.define("Segmented", (A, s, app, p)=>{
+      const { value, options=[], name } = p;
+      return A.Div({ tw:"inline-flex bg-[var(--c-soft)] p-1 rounded-xl border border-white/10" },{
+        default: options.map(opt => A.Button({
+          tw: `px-3 py-1 rounded-lg text-sm font-bold ${value===opt.value? 'bg-[var(--c-primary)] text-white':'text-slate-300'}`,
+          "data-onclick": p.onChange, "data-value": opt.value, name
+        }, { default:[opt.label] }))
+      })
+    })
+  }
+
+  // Emoji icon helper
+  const I = (emoji, tw="") => A.Span({ tw: `select-none ${tw}` }, { default: [emoji] });
+
+  // Currency helper
+  const cur = (s,n)=> new Intl.NumberFormat(s.meta?.locale||'ar-EG', { style:'currency', currency:s.meta?.currency||'EGP' }).format(+n||0);
+  const langOf = s => String(s.meta?.locale||'ar').toLowerCase().startsWith('ar')? 'ar' : 'en';
+  const T = {
+    ar:{ search:'ابحث عن صنف...', dine_in:'صالة', takeaway:'سفري', delivery:'توصيل', new_order:'جديد', in_preparation:'تحت التجهيز', prepared:'جاهز', delivered:'تم التسليم', paid:'مدفوع', tables:'الطاولات', reports:'التقارير', startShift:'بدء وردية', endShift:'إنهاء وردية', shift:'وردية', login:'تسجيل دخول', logout:'تسجيل خروج', categories:'التصنيفات', subtotal:'المجموع', discounts:'خصومات', service:'خدمة', deliveryFee:'توصيل', vat:'ضريبة', total:'الإجمالي', save:'حفظ مؤقت', settle:'تحصيل وطباعة', addPayLine:'إضافة دفعة', splitBill:'تقسيم الدفع', modifiers:'التعديلات', qty:'كمية', remove:'حذف', note:'ملاحظة', customer:'العميل', driver:'السائق', billDiscount:'خصم الفاتورة', lock:'حجز', unlock:'فك الحجز', reservation:'حجز', tablesAssign:'ربط الطاولات', pickedTables:'الطاولات المحددة', seats:'مقاعد', capacity:'سعة' },
+    en:{ search:'Search item...', dine_in:'Dine‑in', takeaway:'Takeaway', delivery:'Delivery', new_order:'New', in_preparation:'In prep', prepared:'Prepared', delivered:'Delivered', paid:'Paid', tables:'Tables', reports:'Reports', startShift:'Start Shift', endShift:'End Shift', shift:'Shift', login:'Login', logout:'Logout', categories:'Categories', subtotal:'Subtotal', discounts:'Discounts', service:'Service', deliveryFee:'Delivery', vat:'VAT', total:'Grand total', save:'Save', settle:'Settle & Print', addPayLine:'Add Payment', splitBill:'Split bill', modifiers:'Modifiers', qty:'Qty', remove:'Remove', note:'Note', customer:'Customer', driver:'Driver', billDiscount:'Bill discount', lock:'Lock', unlock:'Unlock', reservation:'Reservation', tablesAssign:'Assign Tables', pickedTables:'Picked Tables', seats:'Seats', capacity:'Capacity' }
+  };
+  const t = (s,k)=> (T[langOf(s)][k]||k);
+
+  // =============== 2) POS reusable blocks ===============
+  const POS = M.Comp.mole.POS || (M.Comp.mole.POS = {});
+
+  POS.ItemCard = ({ item, state }) => {
+    const name = item.translations?.[langOf(state)]?.name || (`#${item.id}`);
+    return A.Button({
+      tw:"card h-full text-start p-2 hover:ring-2 ring-emerald-500 transition transform hover:-translate-y-0.5",
+      "data-onclick":"addToOrder", "data-id": item.id
+    }, { default:[
+      A.Div({ tw:"aspect-[4/3] w-full overflow-hidden rounded-xl mb-2 bg-[var(--c-soft)]" }, { default:[
+        item.image ? A.Img({ src:item.image, alt:name, tw:"w-full h-full object-cover" }) : I('🍔','text-5xl flex h-full items-center justify-center')
+      ]}),
+      A.Div({ tw:"font-semibold" }, { default:[ name ] }),
+      A.Div({ tw:"text-sm text-slate-400" }, { default:[ cur(state, item.price) ] })
+    ]})
+  }
+
+  POS.OrderLine = ({ line, state }) => A.Div({
+    tw:"py-2 px-2 flex items-center gap-3 border-b border-white/10 hover:bg-white/5 cursor-pointer",
+    "data-onclick":"openLineActions", "data-id": line.uid
+  }, { default:[
+    A.Div({ tw:"flex-1" }, { default:[
+      A.Div({ tw:"font-semibold" }, { default:[ line.name ] }),
+      ...(line.selectedModifiers||[]).map(m => A.Div({ tw:"text-xs text-emerald-400 ps-2" }, { default:[`+ ${m.name} (${cur(state, m.price||0)})`] })),
+      (line.note ? A.Div({ tw:"text-xs text-amber-400 ps-2" }, { default:[`📝 ${line.note}`] }) : null)
+    ]}),
+    A.Div({ tw:"font-semibold" }, { default:[`× ${line.qty}`] }),
+    A.Div({ tw:"w-24 text-right font-bold" }, { default:[ cur(state, line.total) ] }),
+    A.Button({ tw:"btn-ghost !p-2 text-red-400", "data-onclick":"confirmDeleteOpen", "data-id":line.uid }, { default:["🗑️"] })
+  ]});
+
+  POS.OrderTotals = ({ totals, state }) => A.Div({ tw:"mt-auto space-y-2" }, { default:[
+    Comp.call("DescriptionList", { items:[
+      { term:t(state,'subtotal'), details:cur(state, totals.subtotal) },
+      { term:t(state,'discounts'), details:cur(state, totals.discount) },
+      { term:t(state,'service'), details:cur(state, totals.service) },
+      { term:t(state,'deliveryFee'), details:cur(state, totals.deliveryFee) },
+      { term:t(state,'vat'), details:cur(state, totals.vat) }
+    ]}),
+    A.Div({ tw:"flex justify-between items-center text-xl font-extrabold border-t border-white/10 pt-3" }, { default:[
+      A.Span({}, { default:[ t(state,'total') ] }), A.Span({}, { default:[ cur(state, totals.total) ] })
+    ]})
+  ]});
+
+  POS.TableCard = ({ tbl, state }) => {
+    const badge = tbl.status==='reserved' ? '🟡' : (tbl.status==='occupied'?'🔴':'🟢');
+    return A.Button({
+      tw:"card p-3 text-start hover:ring-2 ring-blue-500",
+      "data-onclick":"pickTableToggle", "data-id": tbl.id
+    }, { default:[
+      A.Div({ tw:"flex items-center justify-between" }, { default:[
+        A.Div({ tw:"font-bold" }, { default:[`#${tbl.number||tbl.id}`] }),
+        A.Span({ tw:"text-xl" }, { default:[badge] })
+      ]}),
+      A.Div({ tw:"text-sm text-slate-400 mt-1" }, { default:[ `${t(state,'capacity')}: ${tbl.capacity||4}` ] }),
+      (tbl.activeOrderIds?.length ? A.Div({ tw:"text-xs mt-1 text-emerald-400" }, { default:[`🧾 ${tbl.activeOrderIds.length} orders`] }) : null)
+    ]})
+  }
+
+  // =============== 3) Regions (pure build) ===============
+  const UI = {};
+
+  UI.header = (s) => {
+    const emp = s.session.employee, sh = s.session.shift;
+    const cats = [{id:'all',name:'الكل'}, ...s.catalog.categories];
+    return A.Div({ tw:"card p-3 flex items-center gap-3 justify-between" }, { default:[
+      A.Div({ tw:"flex items-center gap-2" }, { default:[
+        A.Button({ tw:"btn-ghost", "data-onclick":"toggleTheme" }, { default:["🌓"] }),
+        A.Button({ tw:"btn-ghost", "data-onclick":"toggleLang" }, { default:["🌐"] }),
+        A.Div({ tw:"chip" }, { default:[ emp? `🪪 ${emp.name}` : 'غير مسجل' ] }),
+        A.Div({ tw:"chip" }, { default:[ sh? `⌚ ${new Date(sh.startedAt).toLocaleTimeString()}` : t(s,'startShift') ] })
+      ]}),
+      A.Div({ tw:"flex-1 flex items-center gap-2" }, { default:[
+        A.Input({ id:"search", placeholder:t(s,'search'), value: s.ui.search||'', tw:"w-full px-4 py-2 rounded-xl bg-[var(--c-soft)] border border-white/10", "data-oninput":"onSearch" }),
+        A.Div({ tw:"hidden lg:flex items-center gap-2" }, { default: cats.map(c=> A.Button({
+          tw:`chip ${s.ui.activeCategory===c.id?'!bg-[var(--c-primary)] !text-white':''}`,
+          "data-onclick":"setCategory", "data-id": c.id
+        }, { default:[ c.name||c.title || `#${c.id}` ] })) })
+      ]}),
+      A.Div({ tw:"flex items-center gap-2" }, { default:[
+        A.Button({ tw:"btn-ghost", "data-onclick":"openTables" }, { default:["🍽️ ", t(s,'tables')] }),
+        A.Button({ tw:"btn-ghost", "data-onclick":"showReports" }, { default:["📊 ", t(s,'reports')] }),
+        A.Button({ tw: sh?"btn-danger":"btn-primary", "data-onclick": sh?"endShift":"startShift" }, { default:[ sh? t(s,'endShift') : t(s,'startShift') ] })
+      ]})
+    ]})
+  }
+
+  UI.menu = (s) => {
+    const q = (s.ui.search||'').trim().toLowerCase();
+    const cat = s.ui.activeCategory||'all';
+    const items = (s.catalog.items||[]).filter(it => (cat==='all'||it.categoryId===cat) && (!q || (it.searchText||'').includes(q) || (it.translations?.ar?.name||'').includes(q) || (it.translations?.en?.name||'').toLowerCase().includes(q)));
+    return A.Div({ tw:"card h-full p-3 flex flex-col" }, { default:[
+      A.Div({ tw:"grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5 gap-3 scroll-y" }, { default: items.map(item => POS.ItemCard({ item, state:s })) })
+    ]})
+  }
+
+  UI.order = (s) => {
+    const o = s.order, totals = s.orderTotals;
+    return A.Div({ tw:"card h-full p-3 flex flex-col" }, { default:[
+      // Order type / customer / tables row
+      A.Div({ tw:"flex items-center gap-2 mb-2" }, { default:[
+        Comp.call('Segmented', { name:'otype', value:o.type, onChange:'setOrderType', options:[
+          { value:'dine_in', label:`🍽️ ${t(s,'dine_in')}` },
+          { value:'takeaway', label:`🥡 ${t(s,'takeaway')}` },
+          { value:'delivery', label:`🚚 ${t(s,'delivery')}` },
+        ]}),
+        (o.type==='dine_in' ? A.Button({ tw:"btn-ghost", "data-onclick":"openTablesAssign" }, { default:["🍽️ ", t(s,'tablesAssign')] }) : null),
+        (o.type!=='dine_in' ? A.Input({ id:'custName', placeholder:t(s,'customer'), value:o.customer?.name||'', tw:"px-3 py-2 rounded-xl bg-[var(--c-soft)] border border-white/10", "data-onchange":"syncCustomer" }) : null),
+        (o.type==='delivery' ? A.Input({ id:'custPhone', placeholder:'📞', value:o.customer?.phone||'', tw:"w-40 px-3 py-2 rounded-xl bg-[var(--c-soft)] border border-white/10", "data-onchange":"syncCustomer" }) : null)
+      ]}),
+
+      // Lines
+      A.Div({ tw:"flex-1 scroll-y divide-y divide-white/5" }, { default: (o.items||[]).map(li => POS.OrderLine({ line: li, state: s })) }),
+
+      // Totals
+      POS.OrderTotals({ totals, state:s }),
+
+      // Actions
+      A.Div({ tw:"flex items-center gap-2 pt-3" }, { default:[
+        A.Button({ tw:"btn-ghost", "data-onclick":"openBillDiscount" }, { default:["🏷️ ", t(s,'billDiscount')] }),
+        A.Div({ tw:"ms-auto" }),
+        A.Button({ tw:"btn-ghost", "data-onclick":"saveOrder" }, { default:["💾 ", t(s,'save')] }),
+        A.Button({ tw:"btn-primary", "data-onclick":"openSplitPay" }, { default:["💳 ", t(s,'splitBill')] }),
+        A.Button({ tw:"btn-primary", "data-onclick":"settleAndPrint" }, { default:["🧾 ", t(s,'settle')] })
+      ]})
+    ]})
+  }
+
+  // =============== 4) Modals region ===============
+  UI.modals = (s) => {
+    const m = s.ui.modal; if(!m) return A.Fragment();
+    const closeBtn = A.Button({ tw:"btn-ghost", "data-onclick":"closeModal" }, { default:["✖"] });
+
+    // Qty modal
+    if(m?.type==='qty'){
+      const li = m.line;
+      return A.Div({ class:"modal-backdrop" }, { default:[
+        A.Div({ tw:"card w-[min(420px,92vw)] p-4 space-y-3" }, { default:[
+          A.Div({ tw:"flex items-center justify-between" }, { default:[ A.Div({ tw:"font-bold" }, { default:[ t(s,'qty')+': '+li.name ] }), closeBtn ] }),
+          A.Input({ id:'qtyInput', type:'number', value: li.qty, min:1, tw:"w-full text-2xl text-center px-3 py-2 rounded-xl bg-[var(--c-soft)] border border-white/10", "data-oninput":"syncQty" }),
+          A.Div({ tw:"grid grid-cols-3 gap-2" }, { default:[..."1234567890"].map(ch=> A.Button({ tw:"btn-ghost", "data-onclick":"qtyKey", "data-ch": ch }, { default:[ch] })) })
+        ]})
+      ]})
+    }
+
+    // Modifiers modal
+    if(m?.type==='modifiers'){
+      const li = m.line, mods = m.mods || [];
+      return A.Div({ class:"modal-backdrop" }, { default:[
+        A.Div({ tw:"card w-[min(680px,96vw)] p-4 space-y-3" }, { default:[
+          A.Div({ tw:"flex items-center justify-between" }, { default:[ A.Div({ tw:"font-bold" }, { default:[`🧩 ${t(s,'modifiers')} — ${li.name}`] }), closeBtn ] }),
+          A.Div({ tw:"grid grid-cols-2 md:grid-cols-3 gap-2 max-h-[50vh] scroll-y" }, { default: mods.map(md => A.Button({
+            tw:`chip flex items-center justify-between ${li.selectedModifiers?.some(x=>x.id===md.id)?'!bg-emerald-600 !text-white':''}`,
+            "data-onclick":"toggleModifier", "data-id": md.id
+          }, { default:[ A.Span({}, { default:[ md.name ] }), A.Span({ tw:"text-sm" }, { default:[ cur(s, md.price||0) ] }) ] })) })
+        ]})
+      ]})
+    }
+
+    // Tables assign modal
+    if(m?.type==='tables'){
+      const picked = new Set((s.order.tableIds||[]));
+      return A.Div({ class:"modal-backdrop" }, { default:[
+        A.Div({ tw:"card w-[min(920px,98vw)] p-4 space-y-3" }, { default:[
+          A.Div({ tw:"flex items-center justify-between" }, { default:[ A.Div({ tw:"font-bold" }, { default:["🍽️ ", t(s,'tablesAssign')] }), closeBtn ] }),
+          A.Div({ tw:"grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2 max-h-[52vh] scroll-y" }, { default:(s.tables||[]).map(tbl=> POS.TableCard({ tbl, state:s })) }),
+          A.Div({ tw:"flex items-center justify-between" }, { default:[
+            A.Div({ tw:"text-sm text-slate-400" }, { default:[`${t(s,'pickedTables')}: ${Array.from(picked).join(', ')||'—'}`] }),
+            A.Div({ tw:"flex items-center gap-2" }, { default:[
+              A.Button({ tw:"btn-ghost", "data-onclick":"createReservationOpen" }, { default:["🔒 ", t(s,'reservation')] }),
+              A.Button({ tw:"btn-primary", "data-onclick":"applyTablesAssign" }, { default:["✅ ", t(s,'tablesAssign')] })
+            ]})
+          ]})
+        ]})
+      ]})
+    }
+
+    // Split payments
+    if(m?.type==='split'){
+      const pay = m.payments||[];
+      return A.Div({ class:"modal-backdrop" }, { default:[
+        A.Div({ tw:"card w-[min(620px,96vw)] p-4 space-y-3" }, { default:[
+          A.Div({ tw:"flex items-center justify-between" }, { default:[ A.Div({ tw:"font-bold" }, { default:["💳 ", t(s,'splitBill')] }), closeBtn ] }),
+          A.Div({ tw:"space-y-2" }, { default:[
+            ...pay.map((p,i)=> A.Div({ tw:"flex items-center gap-2" }, { default:[
+              A.Select({ "data-onchange":"changePayMethod", "data-i": i, 'data-value': p.method, tw:"px-3 py-2 rounded-xl bg-[var(--c-soft)] border border-white/10" }, { default:[
+                A.Option({ value:'cash' }, { default:['💵 Cash'] }),
+                A.Option({ value:'card' }, { default:['💳 Card'] }),
+                A.Option({ value:'wallet' }, { default:['📱 Wallet'] })
+              ]}),
+              A.Input({ type:'number', step:'0.01', value:p.amount, 'data-oninput':'changePayAmount', 'data-i':i, tw:"w-36 px-3 py-2 rounded-xl bg-[var(--c-soft)] border border-white/10" })
+            ]})),
+            A.Button({ tw:"btn-ghost", "data-onclick":"addPayLine" }, { default:["➕ ", t(s,'addPayLine')] })
+          ]}),
+          A.Div({ tw:"flex items-center justify-end gap-2" }, { default:[
+            A.Button({ tw:"btn-primary", "data-onclick":"confirmSplit" }, { default:["✅ ", t(s,'settle')] })
+          ]})
+        ]})
+      ]})
+    }
+
+    // Reports (orders list + filters)
+    if(m?.type==='reports'){
+      const rs = s.reports||{ orders:[], filters:{} };
+      return A.Div({ class:"modal-backdrop" }, { default:[
+        A.Div({ tw:"card w-[min(1080px,98vw)] p-4 space-y-3" }, { default:[
+          A.Div({ tw:"flex items-center justify-between" }, { default:[
+            A.Div({ tw:"font-bold" }, { default:["📊 ", t(s,'reports')] }),
+            closeBtn
+          ]}),
+          A.Div({ tw:"flex items-center gap-2" }, { default:[
+            A.Select({ 'data-onchange':'setReportStatus', 'data-value': rs.filters?.status||'' , tw:"px-3 py-2 rounded-xl bg-[var(--c-soft)] border border-white/10" },{ default:[
+              A.Option({ value:'' },{ default:['🔎 كل الحالات'] }),
+              A.Option({ value:'new_order' },{ default:[t(s,'new_order')] }),
+              A.Option({ value:'in_preparation' },{ default:[t(s,'in_preparation')] }),
+              A.Option({ value:'prepared' },{ default:[t(s,'prepared')] }),
+              A.Option({ value:'delivered' },{ default:[t(s,'delivered')] }),
+              A.Option({ value:'paid' },{ default:[t(s,'paid')] })
+            ]}),
+            A.Input({ placeholder:'ابحث برقم/اسم', value:rs.filters?.query||'', 'data-oninput':'setReportQuery', tw:"flex-1 px-3 py-2 rounded-xl bg-[var(--c-soft)] border border-white/10" })
+          ]}),
+          A.Div({ tw:"max-h-[60vh] scroll-y" }, { default:[
+            A.Table({ tw:"w-full text-sm" }, { default:[
+              A.Thead({}, { default:[ A.Tr({}, { default:[ 'رقم','النوع','الحالة','الطاولات','العميل','الإجمالي','الكاشير' ].map(h=> A.Th({ tw:"text-start py-2" },{ default:[h] })) ]) ] }),
+              A.Tbody({}, { default:(rs.orders||[]).map(o=> A.Tr({ tw:"border-t border-white/10 cursor-pointer hover:bg-white/5", "data-onclick":"openReportOrder", "data-id":o.id }, { default:[
+                A.Td({ tw:"py-1" }, { default:[o.id] }),
+                A.Td({}, { default:[o.type] }),
+                A.Td({}, { default:[o.status] }),
+                A.Td({}, { default:[(o.tableIds||[]).join(', ')] }),
+                A.Td({}, { default:[ o.type==='delivery' ? (o.customer?.name||'—') : (o.customer?.name||'عميل نقدي') ] }),
+                A.Td({}, { default:[ cur(s, o.totals?.total||o.total||0) ] }),
+                A.Td({}, { default:[ o.cashierName || '—' ] })
+              ]})) })
+            ]})
+          ]})
+        ]})
+      ]})
+    }
+
+    return A.Fragment();
+  }
+
+  // =============== 5) Public API ===============
+  w.POS_UI = UI; // expose builders
+})();

--- a/pos.html
+++ b/pos.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>POS — نظام إدارة المطاعم الاحترافي (Mishkah v5)</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    :root{
+      --c-bg:#0f172a;           /* slate-900 */
+      --c-card:#0b1220;         /* deep dark */
+      --c-soft:#111827;         /* slate-800 */
+      --c-text:#e5e7eb;         /* slate-200 */
+      --c-muted:#94a3b8;        /* slate-400 */
+      --c-primary:#22c55e;      /* emerald-500 */
+      --c-danger:#ef4444;       /* red-500 */
+      --c-accent:#2563eb;       /* blue-600 */
+    }
+    html[data-theme="light"]{
+      --c-bg:#f8fafc;           /* slate-50 */
+      --c-card:#ffffff;
+      --c-soft:#f1f5f9;         /* slate-100 */
+      --c-text:#0f172a;         /* slate-900 */
+      --c-muted:#64748b;        /* slate-500 */
+      --c-primary:#16a34a;      /* green-600 */
+      --c-danger:#dc2626;       /* red-600 */
+      --c-accent:#2563eb;       /* blue-600 */
+    }
+    body{ background:var(--c-bg); color:var(--c-text); }
+    .card{ background:var(--c-card); border:1px solid rgba(148,163,184,.15); border-radius:16px; box-shadow:0 10px 30px rgba(0,0,0,.12); }
+    .btn{ display:inline-flex; align-items:center; justify-content:center; gap:.5rem; padding:.65rem 1rem; border-radius:12px; font-weight:700; border:1px solid transparent; transition:.15s ease; }
+    .btn-primary{ background:var(--c-primary); color:#fff; }
+    .btn-ghost{ background:transparent; color:var(--c-text); border-color:rgba(148,163,184,.25); }
+    .btn-danger{ background:var(--c-danger); color:#fff; }
+    .btn:hover{ transform:translateY(-1px); opacity:.95 }
+    .chip{ background:var(--c-soft); color:var(--c-text); border:1px solid rgba(148,163,184,.15); padding:.35rem .75rem; border-radius:999px; font-weight:600 }
+    .kbd{ font-feature-settings:"ss01" on; background:var(--c-soft); padding:.15rem .45rem; border-radius:.5rem; border:1px solid rgba(148,163,184,.25); color:var(--c-text); }
+    .scroll-y{ overflow-y:auto }
+
+    /* Print — 80mm thermal */
+    @media print{
+      @page{ size:80mm auto; margin:6mm }
+      body{ background:#fff; color:#000 }
+      #app, #hdr, #layout, #modals{ display:none !important }
+      #printer{ display:block !important }
+    }
+  </style>
+</head>
+<body class="min-h-screen">
+  <div id="app" class="h-screen w-screen p-3 grid grid-rows-[auto,1fr] gap-3">
+    <header id="hdr"></header>
+    <main id="layout" class="grid grid-cols-12 gap-3 overflow-hidden">
+      <section id="menu-panel" class="col-span-12 xl:col-span-7 2xl:col-span-8 h-full"></section>
+      <aside id="order-panel" class="col-span-12 xl:col-span-5 2xl:col-span-4 h-full"></aside>
+    </main>
+    <div id="modals"></div>
+    <div id="printer" class="hidden"></div>
+  </div>
+
+  <!-- Core & App -->
+  <script src="mishkah-v5.js"></script>
+  <!-- optional: seed data (ignored if IndexedDB already filled) -->
+  <script src="mock-data.js" defer></script>
+  <script src="pos-comp.js" defer></script>
+  <script src="pos.js" defer></script>
+</body>
+</html>

--- a/pos.js
+++ b/pos.js
@@ -1,0 +1,196 @@
+(function(w){
+  const { Core } = w.Mishkah;
+  const U = w.Mishkah.utils || {};
+
+  // ====================== 1) IndexedDB (schema v7) ======================
+  const DB = new U.IndexedDB('rms-pos', 7, (db, oldV) => {
+    if(oldV < 1){ db.createObjectStore('settings',{ keyPath:'id' }) }
+    if(oldV < 2){ db.createObjectStore('employees',{ keyPath:'id' }) }
+    if(oldV < 3){ db.createObjectStore('tables',{ keyPath:'id' }) }
+    if(oldV < 4){ db.createObjectStore('categories',{ keyPath:'id' }); db.createObjectStore('items',{ keyPath:'id' }) }
+    if(oldV < 5){ db.createObjectStore('customers',{ keyPath:'phone' }) }
+    if(oldV < 6){ const s=db.createObjectStore('shifts',{ keyPath:'id' }); s.createIndex('status','status'); const o=db.createObjectStore('orders',{ keyPath:'id' }); o.createIndex('status','status'); o.createIndex('tableIds','tableIds',{ multiEntry:true }); const p=db.createObjectStore('payments',{ keyPath:'id' }); p.createIndex('orderId','orderId'); p.createIndex('shiftId','shiftId'); const r=db.createObjectStore('reservations',{ keyPath:'id' }); r.createIndex('tableId','tableId'); r.createIndex('dateTime','dateTime'); }
+    if(oldV < 7){ if(!db.objectStoreNames.contains('drivers')) db.createObjectStore('drivers',{ keyPath:'id' }) }
+  });
+
+  // ====================== 2) Helpers & Models ======================
+  const genId = p => `${p}-${Date.now()}-${Math.floor(Math.random()*1e5)}`;
+  const round = x => Math.round((+x + Number.EPSILON) * 100) / 100;
+
+  const calcLineTotal = (line) => {
+    const base = +line.price || 0;
+    const mods = (line.selectedModifiers||[]).reduce((s,m)=> s + (+m.price||0), 0);
+    return round((base + mods) * (line.qty||1) * (1 - (+line.discountRate||0)));
+  };
+
+  const calcOrderTotals = (o, settings) => {
+    const subtotal = round((o.items||[]).reduce((a,b)=> a + (+b.total||0), 0));
+    const discount = round(+o.orderDiscount||0);
+    const service = o.type==='dine_in' ? round((subtotal - discount) * +(settings.service_charge_rate||0)) : 0;
+    const deliveryFee = o.type==='delivery' ? round(o.deliveryFee!=null? +o.deliveryFee : +(settings.default_delivery_fee||0)) : 0;
+    const taxable = round(Math.max(0, subtotal - discount + service + deliveryFee));
+    const vat = round(taxable * +(settings.tax_rate||0));
+    const total = round(taxable + vat);
+    return { subtotal, discount, service, deliveryFee, vat, total };
+  };
+
+  const makeLine = (it, lang) => {
+    const name = it.translations?.[lang]?.name || (`Item #${it.id}`);
+    const line = { uid:genId('li'), itemId:it.id, name, price:+it.price, qty:1, selectedModifiers:[], note:'', discountRate:0, total:0 };
+    line.total = calcLineTotal(line); return line;
+  }
+
+  const makeOrder = (type) => ({ id:genId('ord'), type, items:[], orderDiscount:0, tableIds:[], customer:null, driverId:null, deliveryFee:null, createdAt:Date.now(), status:'new_order' });
+
+  const ensureSearchText = (it) => { if(!it.searchText){ const ar=it.translations?.ar?.name||''; const en=(it.translations?.en?.name||''); it.searchText = (String(ar)+' '+String(en)+' '+String(it.description||'')).toLowerCase(); } return it }
+
+  // ====================== 3) App ======================
+  const app = Core.createApp({
+    root:'#app', locale:'ar-EG', dir:'auto', theme:'auto', persistEnv:true,
+    perfPolicy:{ maxMs:16, mode:'last' }, guardianMode:'warn',
+    initial:{
+      meta:{ currency:'EGP', locale:'ar-EG', dir:'rtl', theme:'light' },
+      settings:{}, catalog:{ categories:[], items:[] },
+      employees:[], drivers:[], tables:[], customers:[],
+      session:{ employee:null, shift:null },
+      order: makeOrder('takeaway'), orderTotals:{ subtotal:0, discount:0, service:0, deliveryFee:0, vat:0, total:0 },
+      ui:{ search:'', activeCategory:'all', modal:null, targetLine:null, tempDiscount:'0', tempNote:'', tablePick:new Set(),
+           payments:[] },
+      reports:{ orders:[], filters:{ status:'', query:'' } },
+      lastPrinted:null, lastPrintedTotals:null
+    },
+
+    // ---------------- Commands (all business logic) ----------------
+    commands:{
+      async boot({ truth, env }){
+        await DB.open();
+        const first = ((await DB.getAll('employees'))||[]).length===0;
+        if(first && w.database){
+          await DB.put('settings', { id:'default', ...(w.database.settings||{}) });
+          await DB.bulkPut('employees', w.database.employees||[]);
+          await DB.bulkPut('tables', w.database.tables||[]);
+          await DB.bulkPut('drivers', w.database.drivers||[]);
+          await DB.bulkPut('categories', w.database.categories||[]);
+          await DB.bulkPut('items', (w.database.items||[]).map(ensureSearchText));
+          await DB.bulkPut('customers', w.database.customers||[]);
+        }
+        const settings = (await DB.get('settings','default')) || { tax_rate:.15, service_charge_rate:.1, default_delivery_fee:10 };
+        const [employees, drivers, tables, categories, items] = await Promise.all([
+          DB.getAll('employees'), DB.getAll('drivers'), DB.getAll('tables'), DB.getAll('categories'), DB.getAll('items')
+        ]);
+        truth.batch(()=>{
+          truth.set(s=> ({...s, settings, employees, drivers, tables, catalog:{ categories, items: items.map(ensureSearchText) }, meta:{...s.meta, currency:(settings.currency?.code||'EGP'), locale:env.get().locale, dir:env.resolvedDir(), theme:env.resolvedTheme()} }));
+          truth.rebuildAll();
+        })
+      },
+
+      toggleTheme:({ env })=> env.toggleTheme(),
+      toggleLang:({ env, truth })=>{ const nxt = env.get().locale.startsWith('ar')? 'en-US' : 'ar-EG'; env.setLocale(nxt); truth.set(s=>({...s, meta:{...s.meta, locale:nxt}})); truth.rebuildAll() },
+
+      onSearch({ truth }, e){ const v = e.target.value||''; truth.set(s=>({...s, ui:{...s.ui, search:v}})); truth.mark('menu-panel') },
+      setCategory({ truth }, e){ const id = e.target.getAttribute('data-id'); truth.set(s=>({...s, ui:{...s.ui, activeCategory:id}})); truth.mark('menu-panel') },
+
+      setOrderType({ truth }, e){ const t = e.target.getAttribute('data-value'); truth.batch(()=>{ truth.set(s=> ({...s, order:{...s.order, type:t}})); truth.mark('order-panel') }) },
+
+      addToOrder({ truth, i18n }, e){ const id = e.target.getAttribute('data-id'); truth.batch(()=>{
+        truth.set(s=>{
+          const it = s.catalog.items.find(x=> String(x.id)===String(id)); if(!it) return s;
+          const line = makeLine(it, (s.meta?.locale||'ar').startsWith('ar')?'ar':'en');
+          const order = { ...s.order, items:[...s.order.items, line] };
+          return { ...s, order, orderTotals: calcOrderTotals(order, s.settings) }
+        });
+        truth.mark('order-panel');
+      }) },
+
+      // ----- Line actions & Qty -----
+      openLineActions({ truth }, e){ const uid=e.currentTarget?.getAttribute('data-id')||e.target.getAttribute('data-id'); truth.set(s=>({...s, ui:{...s.ui, modal:{ type:'qty', line: (s.order.items||[]).find(x=>x.uid===uid) }}})); truth.mark('modals') },
+      syncQty({ truth }, e){ const val = Math.max(1, Math.floor(+e.target.value||1)); truth.batch(()=>{ truth.set(s=>{ const li=s.ui.modal?.line; if(!li) return s; li.qty = val; li.total = calcLineTotal(li); return { ...s, order:{...s.order}, orderTotals: calcOrderTotals(s.order, s.settings) } }); truth.mark('order-panel') }) },
+      qtyKey({ truth }, e){ const ch = e.target.getAttribute('data-ch'); const inp = document.querySelector('#qtyInput'); if(!inp) return; if(ch==='C') inp.value=''; else inp.value = (inp.value||'') + ch; inp.dispatchEvent(new Event('input',{ bubbles:true })) },
+
+      // ----- Modifiers -----
+      openModifiers({ truth }, e){ const uid = e.target.getAttribute('data-id'); truth.set(s=>{ const li=(s.order.items||[]).find(x=>x.uid===uid); return { ...s, ui:{...s.ui, modal:{ type:'modifiers', line:li, mods: (li?.modifiers||li?.availableModifiers||s.settings?.modifiers||[]) } } } }); truth.mark('modals') },
+      toggleModifier({ truth }, e){ const id = e.target.getAttribute('data-id'); truth.batch(()=>{ truth.set(s=>{ const li=s.ui.modal?.line; if(!li) return s; const has = (li.selectedModifiers||[]).some(m=>String(m.id)===String(id)); const src = s.ui.modal.mods || []; const mod = src.find(m=> String(m.id)===String(id)); const sel = new Set((li.selectedModifiers||[]).map(x=>String(x.id))); if(has) sel.delete(String(id)); else if(mod) sel.add(String(id)); li.selectedModifiers = Array.from(sel).map(x=> src.find(m=>String(m.id)===x)).filter(Boolean); li.total = calcLineTotal(li); return { ...s, order:{...s.order}, orderTotals: calcOrderTotals(s.order, s.settings) } }); truth.mark('order-panel') }) },
+
+      confirmDeleteOpen({ truth }, e){ const uid=e.target.getAttribute('data-id'); truth.set(s=>({...s, ui:{...s.ui, modal:{ type:'confirmDel', uid } }})); truth.mark('modals') },
+      confirmDelete({ truth }){ truth.batch(()=>{ truth.set(s=>{ const uid=s.ui.modal?.uid; const items=(s.order.items||[]).filter(x=>x.uid!==uid); const order={...s.order, items}; return { ...s, order, orderTotals: calcOrderTotals(order, s.settings), ui:{...s.ui, modal:null} } }); truth.mark('order-panel'); truth.mark('modals') }) },
+
+      // ----- Customer -----
+      syncCustomer({ truth }, e){ const id=e.target.id, v=e.target.value; truth.batch(()=>{ truth.set(s=>{ const c={ ...(s.order.customer||{}), [id==='custName'?'name':'phone']: v }; return { ...s, order:{ ...s.order, customer:c } } }); truth.mark('order-panel') }) },
+
+      // ----- Tables & Reservations -----
+      openTables({ truth }){ truth.set(s=>({...s, ui:{...s.ui, modal:{ type:'tables' }}})); truth.mark('modals') },
+      openTablesAssign({ truth }){ truth.set(s=>({...s, ui:{...s.ui, modal:{ type:'tables' }}})); truth.mark('modals') },
+      pickTableToggle({ truth }, e){ const id = e.target.getAttribute('data-id'); truth.set(s=>{ const pick=new Set(s.ui.tablePick||new Set()); if(pick.has(id)) pick.delete(id); else pick.add(id); return { ...s, ui:{...s.ui, tablePick:pick} } }); },
+      async applyTablesAssign({ truth }){ const pick = (s=> Array.from(s.ui.tablePick||new Set()))(truth.get()); truth.batch(()=>{ truth.set(s=> ({ ...s, order:{...s.order, tableIds: pick }, ui:{...s.ui, tablePick:new Set(), modal:null} })); truth.mark('order-panel'); truth.mark('modals') }) },
+
+      async createReservationOpen({ truth }){ const pick=Array.from((truth.get().ui.tablePick||new Set())); const name=prompt('اسم العميل:'); const phone=prompt('هاتف:'); const at=prompt('موعد (ISO):', new Date(Date.now()+60*60*1000).toISOString()); const pax=+prompt('عدد الأفراد:', '2'); if(!name||!at) return; const resv={ id:genId('resv'), tableId: pick[0]||null, customer:{ name, phone }, pax, dateTime:at, status:'reserved' }; await DB.put('reservations', resv); alert('تم إنشاء الحجز'); },
+
+      // ----- Order save / settle / split -----
+      saveOrder({ truth }){ truth.batch(()=>{ truth.set(s=>{ const o={...s.order}; const totals = calcOrderTotals(o, s.settings); o.totals = totals; return { ...s, order:o, orderTotals:totals } }); truth.mark('order-panel') }) },
+
+      openSplitPay({ truth }){ const due = truth.get().orderTotals.total; truth.set(s=>({...s, ui:{...s.ui, modal:{ type:'split', payments:[ { method:'cash', amount:due } ] }}})); truth.mark('modals') },
+      addPayLine({ truth }){ truth.set(s=>{ const m=s.ui.modal; if(!m||m.type!=='split') return s; return { ...s, ui:{...s.ui, modal:{ ...m, payments:[...m.payments, { method:'cash', amount:0 }] } } } }); truth.mark('modals') },
+      changePayMethod({ truth }, e){ const i=+e.target.getAttribute('data-i'); const v=e.target.value; truth.set(s=>{ const m=s.ui.modal; m.payments[i].method=v; return { ...s, ui:{...s.ui, modal:m } } }); },
+      changePayAmount({ truth }, e){ const i=+e.target.getAttribute('data-i'); const v=+e.target.value||0; truth.set(s=>{ const m=s.ui.modal; m.payments[i].amount=v; return { ...s, ui:{...s.ui, modal:m } } }); },
+      async confirmSplit({ truth }){
+        const s = truth.get(); const o = s.order; const totals = s.orderTotals; const shift = s.session.shift; const payLines = (s.ui.modal?.payments||[]);
+        const paidSum = round(payLines.reduce((a,b)=>a+(+b.amount||0),0)); if(paidSum < totals.total){ alert('المبلغ المدفوع غير كافٍ'); return }
+        const order = { ...o, status:'paid', paidAt:Date.now(), totals };
+        await DB.put('orders', order);
+        for(const p of payLines){ await DB.put('payments', { id:genId('pay'), orderId:order.id, shiftId:shift?.id||null, method:p.method, amount:+p.amount||0, at:Date.now() }) }
+        // print
+        this.printInvoice({ truth }, null, order);
+        truth.batch(()=>{ truth.set(st=> ({ ...st, order: makeOrder(st.order.type), orderTotals: calcOrderTotals(makeOrder(st.order.type), st.settings), ui:{...st.ui, modal:null} })); truth.mark('order-panel'); truth.mark('modals') })
+      },
+
+      settleAndPrint(ctx){ ctx.dispatch('openSplitPay'); },
+
+      // ----- Reports -----
+      async showReports({ truth }){ const all = await DB.getAll('orders'); truth.set(s=> ({ ...s, reports:{ orders: all.sort((a,b)=> b.createdAt-a.createdAt), filters:{ status:'', query:'' } }, ui:{...s.ui, modal:{ type:'reports' }} })); truth.mark('modals') },
+      setReportStatus({ truth }, e){ const v=e.target.value; truth.set(s=> ({ ...s, reports:{ ...s.reports, filters:{ ...s.reports.filters, status:v } } })); this.refreshReports({ truth }) },
+      setReportQuery({ truth }, e){ const v=e.target.value||''; truth.set(s=> ({ ...s, reports:{ ...s.reports, filters:{ ...s.reports.filters, query:v } } })); this.refreshReports({ truth }) },
+      async refreshReports({ truth }){ const s=truth.get(); const all=await DB.getAll('orders'); const f=s.reports.filters||{}; const list=all.filter(o=> (!f.status||o.status===f.status) && (!f.query|| String(o.id).includes(f.query)|| (o.customer?.name||'').includes(f.query)) ).sort((a,b)=>b.createdAt-a.createdAt); truth.set(st=> ({ ...st, reports:{ ...st.reports, orders:list } })); truth.mark('modals') },
+      openReportOrder({ truth }, e){ const id=e.currentTarget?.getAttribute('data-id')||e.target.getAttribute('data-id'); alert('فتح الطلب '+id+' — للتوسعة: تحميله في اللوحة اليمنى لإعادة فتحه/الطباعة/التحصيل'); },
+
+      // ----- Shift -----
+      async startShift({ truth }){ const sh={ id:genId('sh'), startedAt:Date.now(), status:'open' }; await DB.put('shifts', sh); truth.set(s=> ({ ...s, session:{ ...s.session, shift: sh } })); truth.mark('hdr') },
+      async endShift({ truth }){ const s=truth.get(); if(!s.session.shift) return; const sh = { ...s.session.shift, endedAt:Date.now(), status:'closed' }; await DB.put('shifts', sh); truth.set(st=> ({ ...st, session:{ ...st.session, shift:null } })); truth.rebuildAll() },
+
+      // ----- Misc -----
+      closeModal({ truth }){ truth.set(s=> ({ ...s, ui:{ ...s.ui, modal:null } })); truth.mark('modals') },
+
+      // Thermal print: simple template
+      printInvoice({ truth }, _e, orderArg){
+        const s = truth.get(); const o = orderArg || s.order; const totals = o.totals || s.orderTotals;
+        const el = document.getElementById('printer');
+        const lines = (o.items||[]).map(li=> `• ${li.name} x${li.qty} — ${round(li.total).toFixed(2)}`).join('<br/>');
+        el.innerHTML = `
+          <div style="font:14px/1.25 monospace;">
+            <div style="text-align:center"><b>فاتورة مبسطة</b></div>
+            <div>رقم: ${o.id}</div>
+            <div>التاريخ: ${new Date(o.createdAt).toLocaleString()}</div>
+            <hr/>
+            <div>${lines}</div>
+            <hr/>
+            <div>إجمالي: ${round(totals.total).toFixed(2)} ${s.meta.currency}</div>
+          </div>`;
+        w.print();
+      }
+    },
+
+    // ---------------- Regions (pure views) ----------------
+    register({ registerRegion }){
+      registerRegion('hdr', '#hdr', (state)=> w.POS_UI.header(state), null, { budget:{ maxMs:12 } });
+      registerRegion('menu-panel', '#menu-panel', (state)=> w.POS_UI.menu(state), null, { budget:{ maxMs:12 } });
+      registerRegion('order-panel', '#order-panel', (state)=> w.POS_UI.order(state), null, { budget:{ maxMs:12 } });
+      registerRegion('modals', '#modals', (state)=> w.POS_UI.modals(state), null, { priority:'high', budget:{ maxMs:8 } });
+      registerRegion('printer', '#printer', (_s)=> '', null, { priority:'low' });
+    }
+  });
+
+  // Bootstrap
+  app.dispatch('boot');
+
+  // Devtools helper (optional)
+  w.__POS = app; // for console inspection
+})();


### PR DESCRIPTION
## Summary
- add a Tailwind-based POS shell page that bootstraps the Mishkah v5 runtime
- implement reusable Mishkah component molecules for POS cards, totals, tables, and modal flows
- wire a Mishkah Core app with IndexedDB persistence, order handling commands, and modal-driven workflows for the POS unit

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d067f664208333adfa601451cad76c