### PR TITLE
Add bill discount modal commands

### DIFF
--- a/pos-comp.js
+++ b/pos-comp.js
@@ -234,6 +234,23 @@
       ]})
     }
 
+    // Bill discount
+    if(m?.type==='billDiscount'){
+      const totals = s.orderTotals || { subtotal:0, discount:0, total:0 };
+      const value = s.ui?.tempDiscount!=null ? s.ui.tempDiscount : String(s.order?.orderDiscount||0);
+      return A.Div({ class:"modal-backdrop" }, { default:[
+        A.Div({ tw:"card w-[min(420px,92vw)] p-4 space-y-3" }, { default:[
+          A.Div({ tw:"flex items-center justify-between" }, { default:[ A.Div({ tw:"font-bold" }, { default:["🏷️ ", t(s,'billDiscount')] }), closeBtn ] }),
+          A.Div({ tw:"text-sm text-slate-400" }, { default:[`${t(s,'subtotal')}: ${cur(s, totals.subtotal)}`] }),
+          A.Div({ tw:"text-sm text-slate-400" }, { default:[`${t(s,'discounts')}: ${cur(s, totals.discount)}`] }),
+          A.Input({ type:'number', min:'0', step:'0.01', value:value, placeholder:cur(s,0), tw:"w-full px-3 py-2 rounded-xl bg-[var(--c-soft)] border border-white/10", "data-oninput":"syncBillDiscount" }),
+          A.Div({ tw:"flex items-center justify-end gap-2" }, { default:[
+            A.Button({ tw:"btn-primary", "data-onclick":"applyBillDiscount" }, { default:["✅ ", t(s,'save')] })
+          ]})
+        ]})
+      ]})
+    }
+
     // Split payments
     if(m?.type==='split'){
       const pay = m.payments||[];

--- a/pos.js
+++ b/pos.js
@@ -128,6 +128,10 @@
       // ----- Order save / settle / split -----
       saveOrder({ truth }){ truth.batch(()=>{ truth.set(s=>{ const o={...s.order}; const totals = calcOrderTotals(o, s.settings); o.totals = totals; return { ...s, order:o, orderTotals:totals } }); truth.mark('order-panel') }) },
 
+      openBillDiscount({ truth }){ truth.set(s=>{ const cur = round(+s.order?.orderDiscount||0); return { ...s, ui:{ ...s.ui, modal:{ type:'billDiscount' }, tempDiscount:String(cur) } } }); truth.mark('modals') },
+      syncBillDiscount({ truth }, e){ const v = e?.target?.value ?? ''; truth.set(s=> ({ ...s, ui:{ ...s.ui, tempDiscount: v } })); truth.mark('modals') },
+      applyBillDiscount({ truth }){ truth.batch(()=>{ truth.set(s=>{ const raw=s.ui.tempDiscount; const amt=Math.max(0, +raw||0); const baseTotals=calcOrderTotals({ ...s.order, orderDiscount:0 }, s.settings); const discount=round(Math.min(amt, baseTotals.subtotal)); const order={ ...s.order, orderDiscount:discount }; const orderTotals=calcOrderTotals(order, s.settings); return { ...s, order, orderTotals, ui:{ ...s.ui, modal:null, tempDiscount:String(discount) } }; }); truth.mark('order-panel'); truth.mark('modals') }) },
+
       openSplitPay({ truth }){ const due = truth.get().orderTotals.total; truth.set(s=>({...s, ui:{...s.ui, modal:{ type:'split', payments:[ { method:'cash', amount:due } ] }}})); truth.mark('modals') },
       addPayLine({ truth }){ truth.set(s=>{ const m=s.ui.modal; if(!m||m.type!=='split') return s; return { ...s, ui:{...s.ui, modal:{ ...m, payments:[...m.payments, { method:'cash', amount:0 }] } } } }); truth.mark('modals') },
       changePayMethod({ truth }, e){ const i=+e.target.getAttribute('data-i'); const v=e.target.value; truth.set(s=>{ const m=s.ui.modal; m.payments[i].method=v; return { ...s, ui:{...s.ui, modal:m } } }); },


### PR DESCRIPTION
## Summary
- add commands to open, edit, and apply bill-level discounts
- render a dedicated bill discount modal in the POS interface

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d06de52f708333a90c679884199651