### PR TITLE
Fix reports table header map syntax

### DIFF
--- a/pos-comp.js
+++ b/pos-comp.js
@@ -300,7 +300,7 @@
           ]}),
           A.Div({ tw:"max-h-[60vh] scroll-y" }, { default:[
             A.Table({ tw:"w-full text-sm" }, { default:[
-              A.Thead({}, { default:[ A.Tr({}, { default:[ 'رقم','النوع','الحالة','الطاولات','العميل','الإجمالي','الكاشير' ].map(h=> A.Th({ tw:"text-start py-2" },{ default:[h] })) ]) ] }),
+              A.Thead({}, { default:[ A.Tr({}, { default:[ 'رقم','النوع','الحالة','الطاولات','العميل','الإجمالي','الكاشير' ].map(h=> A.Th({ tw:"text-start py-2" },{ default:[h] })) ] }) ] }),
               A.Tbody({}, { default:(rs.orders||[]).map(o=> A.Tr({ tw:"border-t border-white/10 cursor-pointer hover:bg-white/5", "data-onclick":"openReportOrder", "data-id":o.id }, { default:[
                 A.Td({ tw:"py-1" }, { default:[o.id] }),
                 A.Td({}, { default:[o.type] }),


### PR DESCRIPTION
## Summary
- remove the extra closing bracket in the reports modal table header so the script parses correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d074ec5e8c833388c2b4d1c02dcc01