### PR TITLE
Redesign POS application shell

### DIFF
--- a/pos-comp.js
+++ b/pos-comp.js
@@ -1,451 +1,1097 @@
 (function (window) {
-    "use strict";
-    const { Comp: C, Atoms: A, utils: U } = window.Mishkah;
+  "use strict";
 
-    C.define('LoginScreen', (A, s, app) => {
-        const pin = s.ui.loginPin || '';
-        return A.Div({
-            uniqueKey: 'login-screen',
-            style: {
-                position: 'fixed', inset: 0, zIndex: 1000,
-                background: 'var(--bg-page)', color: 'var(--text-default)',
-                display: 'flex', alignItems: 'center', justifyContent: 'center'
-            }
+  const M = window.Mishkah || {};
+  const C = M.Comp;
+  const U = (M.utils) || {};
+  if (!C || !window.Mishkah || !window.Mishkah.Atoms) return;
+
+  const cx = (...classes) => classes.filter(Boolean).join(" ");
+  const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
+  C.define("POSRoot", (A, s, app) => {
+    const stage = s.ui.stage;
+    if (stage === "login") {
+      return app.call("POSLoginScreen", { uniqueKey: "login-screen" });
+    }
+    if (stage === "shift-setup") {
+      return app.call("POSShiftSetup", { uniqueKey: "shift-setup" });
+    }
+    return app.call("POSViewport", { uniqueKey: "pos-root" });
+  });
+
+  C.define("POSLoginScreen", (A, s, app) => {
+    const login = s.ui.login;
+    const pinLength = clamp((login.pin || "").length, 0, 6);
+
+    return A.Div({
+      style: {
+        position: "fixed",
+        inset: 0,
+        background: "var(--bg-page)",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "32px",
+        padding: "24px"
+      }
+    }, {
+      default: [
+        A.Div({ style: { textAlign: "center", maxWidth: "360px" } }, {
+          default: [
+            A.H1({ style: { fontSize: "2rem", marginBottom: "8px", fontWeight: 700 } }, {
+              default: [app.i18n.t("ui.welcome")] }),
+            A.P({ style: { fontSize: "1rem", color: "var(--text-subtle)" } }, {
+              default: [app.i18n.t("ui.enter_pin")] })
+          ]
+        }),
+        A.Div({
+          style: {
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "12px",
+            direction: "ltr"
+          }
         }, {
-            default: [
-                A.Div({ style: { width: 'min(90vw, 380px)', textAlign: 'center' } }, {
-                    default: [
-                        A.h1({ style: { fontSize: '2rem', fontWeight: 700, marginBottom: '8px' } }, { default: [app.i18n.t('ui.welcome')] }),
-                        A.p({ style: { color: 'var(--text-subtle)', marginBottom: '24px' } }, { default: [app.i18n.t('ui.enterPin')] }),
-                        A.Div({
-                            style: {
-                                display: 'flex', justifyContent: 'center', gap: '12px', marginBottom: '24px',
-                                direction: 'ltr', height: '48px'
-                            }
-                        }, {
-                            default: U.range(4, 0).map(i =>
-                                A.Div({
-                                    style: {
-                                        width: '40px', height: '48px', borderRadius: '12px',
-                                        background: 'var(--bg-surface)', border: '1px solid var(--border-default)',
-                                        display: 'flex', alignItems: 'center', justifyContent: 'center',
-                                        fontSize: '24px'
-                                    }
-                                }, { default: [pin.length > i ? '●' : ''] })
-                            )
-                        }),
-                        s.ui.loginError ? app.call('InlineAlert', { intent: 'danger', text: s.ui.loginError }) : null,
-                        app.call('Numpad', {
-                            onInputCommand: 'updateLoginPin',
-                            onConfirmCommand: 'attemptLogin',
-                            onClearCommand: 'clearLoginPin',
-                            confirmLabel: app.i18n.t('ui.login')
-                        })
-                    ]
-                })
-            ]
-        });
-    });
-
-    C.define('Numpad', (A, s, app, p) => {
-        const keys = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '.', '0', '⌫'];
-        const btnStyle = {
-            height: '64px', borderRadius: '16px', background: 'var(--bg-surface)',
-            border: '1px solid var(--border-default)', fontSize: '24px', fontWeight: 500,
-            color: 'var(--text-default)'
-        };
-
-        return A.Div({ style: { display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '12px', userSelect: 'none' } }, {
-            default: [
-                ...keys.map(key => app.call('Button', {
-                    text: key,
-                    style: btnStyle,
-                    'data-onclick': p.onInputCommand,
-                    'data-key': key
-                })),
-                p.onClearCommand ? app.call('Button', { text: app.i18n.t('ui.clear'), 'data-onclick': p.onClearCommand, style: { ...btnStyle, gridColumn: 'span 1' } }) : A.Span(),
-                p.onConfirmCommand ? app.call('Button', { text: p.confirmLabel || app.i18n.t('ui.confirm'), 'data-onclick': p.onConfirmCommand, intent: 'success', style: { ...btnStyle, gridColumn: 'span 2' } }) : null
-            ]
-        });
-    });
-
-    C.define('POSHeader', (A, s, app) => {
-        const session = s.session || {};
-        const cashierName = session.cashier ? session.cashier.full_name : '...';
-        const shiftInfo = session.shift ? `${app.i18n.t('ui.shift')} #${session.shift.id}` : app.i18n.t('ui.noShift');
-
-        return A.Header({
-            style: {
-                gridArea: 'header', background: 'var(--bg-surface)', color: 'var(--text-default)',
-                borderBottom: '1px solid var(--border-default)', padding: '0 16px',
-                display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-                height: '64px'
-            }
-        }, {
-            default: [
-                A.Div({ style: { display: 'flex', alignItems: 'center', gap: '16px' } }, {
-                    default: [
-                        A.Div({ style: { fontSize: '24px', fontWeight: 700, color: 'var(--primary)' } }, { default: ['Mishkah POS'] }),
-                        A.Div({}, {
-                            default: [
-                                A.Div({ style: { fontWeight: 700 } }, { default: [cashierName] }),
-                                A.Div({ style: { fontSize: '12px', color: 'var(--text-subtle)' } }, { default: [shiftInfo] })
-                            ]
-                        })
-                    ]
-                }),
-                A.Div({ style: { display: 'flex', alignItems: 'center', gap: '8px' } }, {
-                    default: [
-                        app.call('Button', { 'data-onclick': 'showTables', text: app.i18n.t('ui.tables'), variant: 'outline' }),
-                        app.call('Button', { 'data-onclick': 'showReports', text: app.i18n.t('ui.reports'), variant: 'outline' }),
-                        app.call('Button', { 'data-onclick': 'toggleTheme', text: '🎨', variant: 'ghost' }),
-                        app.call('Button', { 'data-onclick': 'switchLanguage', text: s.env.locale === 'ar' ? 'EN' : 'AR', variant: 'ghost' }),
-                        app.call('Button', { 'data-onclick': 'logout', text: app.i18n.t('ui.logout'), intent: 'danger', variant: 'ghost' }),
-                    ]
-                })
-            ]
-        });
-    });
-    
-    C.define('MenuPanel', (A, s, app) => {
-        const { catalog, env } = s;
-        const currentCat = env.currentCategory || 'all';
-        const searchQuery = (env.searchQuery || '').toLowerCase();
-        
-        const filteredItems = catalog.items.filter(item => {
-            const inCategory = currentCat === 'all' || item.category === currentCat;
-            if (!inCategory) return false;
-            if (!searchQuery) return true;
-            
-            const name = (item.translations[s.env.locale] || item.translations.en).name || '';
-            return name.toLowerCase().includes(searchQuery);
-        });
-
-        return A.Div({
-            style: { gridArea: 'menu', background: 'var(--bg-page)', padding: '16px', display: 'flex', flexDirection: 'column' }
-        }, {
-            default: [
-                A.Div({ style: { display: 'flex', gap: '8px', marginBottom: '16px', flexWrap: 'wrap' } }, {
-                    default: catalog.categories.map(cat =>
-                        app.call('Chip', {
-                            'data-onclick': 'selectCategory',
-                            'data-id': cat.id,
-                            label: (cat.translations[s.env.locale] || cat.translations.en).name,
-                            active: currentCat === cat.id
-                        })
-                    )
-                }),
-                A.Div({ style: { marginBottom: '16px' } }, {
-                    default: [ app.call('Input', { placeholder: app.i18n.t('ui.searchItems'), value: s.env.searchQuery || '', 'data-oninput': 'setSearchQuery' }) ]
-                }),
-                A.Div({ class: 'no-scrollbar', style: { flex: '1 1 auto', overflowY: 'auto', display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))', gap: '12px' } }, {
-                    default: filteredItems.map(item => app.call('MenuCard', { item, locale: s.env.locale }))
-                })
-            ]
-        });
-    });
-
-    C.define('MenuCard', (A, s, app, p) => {
-        const { item, locale } = p;
-        const name = (item.translations[locale] || item.translations.en).name;
-        return A.Div({
-            'data-onclick': 'addToOrder',
-            'data-item-id': item.id,
-            style: {
-                cursor: 'pointer', background: 'var(--bg-surface)', borderRadius: '16px',
-                border: '1px solid var(--border-default)', overflow: 'hidden',
-                display: 'flex', flexDirection: 'column'
-            }
-        }, {
-            default: [
-                A.Img({ src: item.image, alt: name, style: { width: '100%', height: '100px', objectFit: 'cover' } }),
-                A.Div({ style: { padding: '8px', flex: '1 1 auto', display: 'flex', flexDirection: 'column', justifyContent: 'space-between' } }, {
-                    default: [
-                        A.Div({ style: { fontSize: '14px', fontWeight: 500, minHeight: '40px' } }, { default: [name] }),
-                        A.Div({ style: { fontSize: '16px', fontWeight: 700, color: 'var(--primary)', textAlign: 'end' } }, { default: [app.helpers.formatCurrency(item.price)] })
-                    ]
-                })
-            ]
-        });
-    });
-
-    C.define('OrderPanel', (A, s, app) => {
-        const { order } = s;
-        return A.Div({
-            style: {
-                gridArea: 'order', background: 'var(--bg-surface)', borderLeft: '1px solid var(--border-default)',
-                display: 'flex', flexDirection: 'column', height: 'calc(100vh - 64px)'
-            }
-        }, {
-            default: [
-                app.call('OrderHeader', { order }),
-                A.Div({ class: 'no-scrollbar', style: { flex: '1 1 auto', overflowY: 'auto', padding: '8px' } }, {
-                    default: [
-                        (!order || !order.lines.length)
-                            ? app.call('EmptyState', { title: app.i18n.t('ui.emptyOrder'), text: app.i18n.t('ui.selectItems') })
-                            : order.lines.map((line, index) => app.call('OrderLine', { line, index }))
-                    ]
-                }),
-                order && order.lines.length > 0 ? app.call('OrderTotals', { totals: order.totals }) : null,
-                order && order.lines.length > 0 ? app.call('OrderActions') : null,
-            ]
-        });
-    });
-
-    C.define('OrderHeader', (A, s, app, p) => {
-        const { order } = p;
-        const type = order ? order.type : 'dine_in';
-        const table = order && order.tableId ? s.tables.find(t => t.id === order.tableId) : null;
-        return A.Div({
-            style: { padding: '12px', borderBottom: '1px solid var(--border-default)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }
-        }, {
-            default: [
-                app.call('Segmented', {
-                    items: [
-                        { id: 'dine_in', label: app.i18n.t('ui.dine_in') },
-                        { id: 'takeaway', label: app.i18n.t('ui.takeaway') },
-                        { id: 'delivery', label: app.i18n.t('ui.delivery') }
-                    ],
-                    activeId: type,
-                    'data-onchange': 'setOrderType'
-                }),
-                A.Div({}, { default: [ table ? app.call('Badge', { children: [table.name] }) : null ] })
-            ]
-        });
-    });
-
-    C.define('OrderLine', (A, s, app, p) => {
-        const { line, index } = p;
-        const btnStyle = { minWidth: '32px', height: '32px', padding: '0 8px', borderRadius: '8px' };
-        const inputStyle = { width: '40px', textAlign: 'center', background: 'var(--bg-page)', border: 'none', borderRadius: '8px', height: '32px' };
-        return A.Div({
-            style: { display: 'flex', alignItems: 'center', padding: '8px', borderRadius: '12px', background: 'var(--bg-ui-hover)' }
-        }, {
-            default: [
-                app.call('Button', { text: '×', 'data-onclick': `removeOrderLine`, 'data-index': index, intent: 'danger', variant: 'ghost', size: 'sm' }),
-                A.Div({ style: { flex: '1 1 auto', margin: '0 8px' } }, {
-                    default: [
-                        A.Div({ style: { fontWeight: 500 } }, { default: [line.name] }),
-                        line.modsText ? A.Div({ style: { fontSize: '12px', color: 'var(--text-subtle)' } }, { default: [line.modsText] }) : null,
-                    ]
-                }),
-                A.Div({ style: { display: 'flex', alignItems: 'center', gap: '4px' } }, {
-                    default: [
-                        app.call('Button', { text: '−', style: btnStyle, 'data-onclick': 'decreaseLineQty', 'data-index': index }),
-                        A.Input({ type: 'text', value: line.qty, readonly: true, style: inputStyle }),
-                        app.call('Button', { text: '+', style: btnStyle, 'data-onclick': 'increaseLineQty', 'data-index': index })
-                    ]
-                }),
-                A.Div({ style: { width: '80px', textAlign: 'end', fontWeight: 700 } }, { default: [app.helpers.formatCurrency(line.total)] })
-            ]
-        });
-    });
-
-    C.define('OrderTotals', (A, s, app, p) => {
-        const { totals } = p;
-        const f = app.helpers.formatCurrency;
-        return A.Div({ style: { padding: '16px', borderTop: '1px solid var(--border-default)' } }, {
-            default: [
-                app.call('DescriptionList', {
-                    items: [
-                        { term: app.i18n.t('ui.subtotal'), details: f(totals.subtotal) },
-                        { term: `${app.i18n.t('ui.service')} (${(s.settings.service_charge_rate * 100).toFixed(0)}%)`, details: f(totals.service) },
-                        { term: `${app.i18n.t('ui.vat')} (${(s.settings.tax_rate * 100).toFixed(0)}%)`, details: f(totals.vat) },
-                    ]
-                }),
-                A.Div({ style: { marginTop: '12px', paddingTop: '12px', borderTop: '2px solid var(--border-default)', display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: '24px', fontWeight: 700 } }, {
-                    default: [
-                        A.Span({}, { default: [app.i18n.t('ui.grandTotal')] }),
-                        A.Span({}, { default: [f(totals.grand)] }),
-                    ]
-                })
-            ]
-        });
-    });
-
-    C.define('OrderActions', (A, s, app) => {
-        return A.Div({ style: { padding: '12px', display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px' } }, {
-            default: [
-                app.call('Button', { text: app.i18n.t('ui.parkOrder'), 'data-onclick': 'parkOrder', variant: 'outline', style: {gridColumn: 'span 2'} }),
-                app.call('Button', { text: app.i18n.t('ui.settle'), 'data-onclick': 'openSettleSheet', intent: 'success', style: { gridColumn: 'span 2', height: '48px', fontSize: '18px' } }),
-            ]
-        });
-    });
-    
-    C.define('TablesModal', (A, s, app) => {
-        return app.call('Modal', {
-            open: s.ui.view === 'tables',
-            title: app.i18n.t('ui.select_table'),
-            onClose: () => app.dispatch('showPosView'),
-            size: 'lg',
-        },{
-            default: [
-                A.Div({ style: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(120px, 1fr))', gap: '16px' } }, {
-                    default: s.tables.map(table => app.call('TableCard', { table }))
-                })
-            ]
-        });
-    });
-
-    C.define('TableCard', (A, s, app, p) => {
-        const { table } = p;
-        const statusColors = {
-            available: 'var(--success)',
-            occupied: 'var(--danger)',
-            reserved: 'var(--brand-warning-h, #f59e0b)',
-        };
-        return A.Div({
-            'data-onclick': 'selectTable',
-            'data-id': table.id,
-            style: {
-                height: '100px',
-                border: `2px solid ${statusColors[table.status]}`,
-                background: 'var(--bg-surface)',
-                borderRadius: '16px',
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'center',
-                justifyContent: 'center',
-                cursor: 'pointer'
-            }
-        }, {
-            default: [
-                A.Div({ style: { fontSize: '20px', fontWeight: 700 } }, { default: [table.name] }),
-                A.Div({ style: { fontSize: '12px', color: 'var(--text-subtle)' } }, { default: [`${table.seats} ${app.i18n.t('ui.seats')}`] })
-            ]
-        });
-    });
-
-    C.define('SettleSheet', (A, s, app) => {
-        const { order, ui } = s;
-        if (!order) return null;
-        const f = app.helpers.formatCurrency;
-        const total = order.totals.grand;
-        const paid = ui.payment.amount || 0;
-        const due = total - paid;
-        
-        return app.call('Sheet', {
-            open: s.ui.view === 'settle',
-            onClose: () => app.dispatch('showPosView'),
-            title: app.i18n.t('ui.settlePayment'),
-            side: 'end',
-            size: 'md'
-        }, {
-            default: [
-                A.Div({ style: { display: 'flex', flexDirection: 'column', gap: '16px' } }, {
-                    default: [
-                        A.Div({ style: { textAlign: 'center' } }, {
-                            default: [
-                                A.Div({ style: { color: 'var(--text-subtle)', fontSize: '14px' } }, { default: [app.i18n.t('ui.totalDue')] }),
-                                A.Div({ style: { fontSize: '48px', fontWeight: 700, color: 'var(--primary)' } }, { default: [f(total)] }),
-                                A.Div({ style: { color: due < 0 ? 'var(--success)' : 'var(--text-default)' } }, { default: [ `${due < 0 ? 'Change' : 'Remaining'}: ${f(Math.abs(due))}`] })
-                            ]
-                        }),
-                        app.call('Numpad', {
-                            onInputCommand: 'updatePaymentAmount',
-                            onClearCommand: 'clearPaymentAmount'
-                        }),
-                        app.call('Button', { text: app.i18n.t('ui.payCash'), 'data-onclick': 'finalizeOrder', intent: 'success', style: { width: '100%', height: '50px' } })
-                    ]
-                })
-            ]
-        });
-    });
-    
-    C.define('ShiftModal', (A, s, app) => {
-        const { session, ui } = s;
-        const isOpen = ui.view === 'shift';
-        if (!isOpen) return null;
-        
-        const isShiftActive = session && session.shift;
-        
-        return app.call('Modal', {
-            open: isOpen,
-            title: isShiftActive ? app.i18n.t('ui.closeShift') : app.i18n.t('ui.openShift'),
-            onClose: () => app.dispatch(isShiftActive ? 'showPosView' : 'logout'),
-            size: 'sm',
-            dismissable: isShiftActive
-        }, {
-            body: [
-                isShiftActive 
-                ? app.call('ShiftSummary', {shift: session.shift})
-                : app.call('FormRow', {label: app.i18n.t('ui.openingFloat')}, {
-                    default: [app.call('Input', {type: 'number', value: ui.openingFloat || '', 'data-oninput': 'updateOpeningFloat'})]
-                })
-            ],
-            footer: [
-                isShiftActive 
-                ? app.call('Button', {text: app.i18n.t('ui.closeShift'), intent: 'danger', 'data-onclick': 'closeShift'})
-                : app.call('Button', {text: app.i18n.t('ui.openShift'), intent: 'success', 'data-onclick': 'openShift'})
-            ]
-        });
-    });
-    
-    C.define('ShiftSummary', (A,s,app,p) => {
-        return app.call('DescriptionList', {
-            items: [
-                {term: app.i18n.t('ui.startTime'), details: new Date(p.shift.startTime).toLocaleTimeString()},
-                {term: app.i18n.t('ui.openingFloat'), details: app.helpers.formatCurrency(p.shift.openingFloat)},
-                {term: app.i18n.t('ui.cashSales'), details: app.helpers.formatCurrency(0)},
-                {term: app.i18n.t('ui.expectedCash'), details: app.helpers.formatCurrency(p.shift.openingFloat)},
-            ]
+          default: Array.from({ length: 4 }).map((_, idx) =>
+            A.Div({
+              style: {
+                width: "56px",
+                height: "68px",
+                borderRadius: "20px",
+                border: "1px solid var(--border-default)",
+                background: "var(--bg-surface)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: "32px",
+                fontWeight: 600
+              }
+            }, { default: [idx < pinLength ? "●" : ""] })
+          )
+        }),
+        login.error ? A.Div({
+          style: {
+            minWidth: "240px",
+            borderRadius: "16px",
+            padding: "12px 16px",
+            background: "rgba(239,68,68,0.12)",
+            color: "var(--danger)",
+            textAlign: "center",
+            fontWeight: 600
+          }
+        }, { default: [login.error] }) : null,
+        app.call("POSPinPad", {
+          keys: ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "⌫"],
+          confirmLabel: app.i18n.t("ui.login"),
+          confirmCommand: "auth.pinSubmit",
+          keyCommand: "auth.pinKey",
+          clearCommand: "auth.pinClear"
         })
-    })
-
-    C.define('ReportsSheet', (A, s, app) => {
-        return app.call('Sheet', {
-            open: s.ui.view === 'reports',
-            onClose: () => app.dispatch('showPosView'),
-            title: app.i18n.t('ui.reports'),
-            side: 'start',
-            size: 'xl'
-        }, {
-            default: [ app.call('DataTablePro', {
-                columns: [
-                    {key: 'id', title: '#'},
-                    {key: 'type', title: app.i18n.t('ui.type')},
-                    {key: 'grand', title: app.i18n.t('ui.total')},
-                    {key: 'cashier', title: app.i18n.t('ui.cashier')},
-                ],
-                rows: s.history.closedOrders.map(o => ({
-                    id: o.id.slice(-4),
-                    type: app.i18n.t(`ui.${o.type}`),
-                    grand: app.helpers.formatCurrency(o.totals.grand),
-                    cashier: o.cashier.full_name,
-                })),
-                ajax: false
-            }) ]
-        });
+      ]
     });
-    
-    C.define('POSRoot', (A, s, app) => {
-        if (!s.session || !s.session.cashier) {
-            return app.call('LoginScreen', { uniqueKey: 'login-screen' });
-        }
-        if (!s.session.shift) {
-            return app.call('ShiftModal');
-        }
+  });
 
-        return A.Div({
-            uniqueKey: 'pos-root',
+  C.define("POSPinPad", (A, s, app, p = {}) => {
+    const keys = p.keys || ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "⌫"];
+    const layout = [];
+    keys.forEach((key) => {
+      layout.push(app.call("Button", {
+        text: key,
+        size: "lg",
+        variant: "ghost",
+        style: {
+          height: "64px",
+          fontSize: "24px",
+          borderRadius: "18px"
+        },
+        "data-onclick": p.keyCommand,
+        "data-key": key
+      }));
+    });
+
+    const buttonsRow = [];
+    if (p.clearCommand) {
+      buttonsRow.push(app.call("Button", {
+        text: app.i18n.t("ui.clear"),
+        variant: "outline",
+        style: { height: "56px", borderRadius: "18px" },
+        "data-onclick": p.clearCommand
+      }));
+    }
+    if (p.confirmCommand) {
+      buttonsRow.push(app.call("Button", {
+        text: p.confirmLabel || app.i18n.t("ui.confirm"),
+        intent: "success",
+        style: { height: "56px", borderRadius: "18px", fontSize: "18px", fontWeight: 600 },
+        "data-onclick": p.confirmCommand
+      }));
+    }
+
+    return A.Div({
+      style: {
+        width: "min(360px, 90vw)",
+        display: "flex",
+        flexDirection: "column",
+        gap: "12px"
+      }
+    }, {
+      default: [
+        A.Div({
+          style: {
+            display: "grid",
+            gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+            gap: "12px"
+          }
+        }, { default: layout }),
+        buttonsRow.length ? A.Div({
+          style: {
+            display: "grid",
+            gridTemplateColumns: `repeat(${buttonsRow.length}, minmax(0, 1fr))`,
+            gap: "12px"
+          }
+        }, { default: buttonsRow }) : null
+      ]
+    });
+  });
+
+  C.define("POSShiftSetup", (A, s, app) => {
+    const cashier = s.session.cashier;
+    const openingFloat = s.ui.shift.openingFloat ?? "";
+    return A.Div({
+      style: {
+        position: "fixed",
+        inset: 0,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "var(--bg-page)",
+        padding: "24px"
+      }
+    }, {
+      default: [
+        app.call("Panel", {
+          style: { width: "min(440px, 95vw)" }
+        }, {
+          header: [app.i18n.t("ui.open_shift")],
+          body: [
+            A.Div({ style: { display: "flex", flexDirection: "column", gap: "12px" } }, {
+              default: [
+                A.Div({ style: { display: "flex", flexDirection: "column", gap: "4px" } }, {
+                  default: [
+                    A.Span({ style: { color: "var(--text-subtle)", fontSize: "14px" } }, {
+                      default: [app.i18n.t("ui.cashier")]
+                    }),
+                    A.Strong({ style: { fontSize: "18px" } }, { default: [cashier ? cashier.full_name : "—"] })
+                  ]
+                }),
+                A.Label({ style: { display: "flex", flexDirection: "column", gap: "6px" } }, {
+                  default: [
+                    A.Span({ style: { fontWeight: 600 } }, { default: [app.i18n.t("ui.opening_float")] }),
+                    app.call("Input", {
+                      type: "number",
+                      min: "0",
+                      step: "0.01",
+                      value: openingFloat,
+                      placeholder: "0.00",
+                      "data-oninput": "shift.updateOpeningFloat"
+                    })
+                  ]
+                })
+              ]
+            })
+          ],
+          footer: [
+            app.call("Button", {
+              text: app.i18n.t("ui.open_shift"),
+              intent: "success",
+              style: { minWidth: "140px", height: "48px" },
+              "data-onclick": "shift.open"
+            })
+          ]
+        })
+      ]
+    });
+  });
+
+  C.define("POSViewport", (A, s, app) => {
+    return A.Div({
+      style: {
+        height: "100vh",
+        width: "100vw",
+        display: "grid",
+        gridTemplateAreas: `'header header' 'menu order' 'footer order'`,
+        gridTemplateRows: "64px 1fr 88px",
+        gridTemplateColumns: "minmax(0, 1fr) clamp(320px, 34vw, 420px)",
+        background: "var(--bg-page)",
+        overflow: "hidden"
+      }
+    }, {
+      default: [
+        app.call("POSTopBar", { uniqueKey: "pos-header" }),
+        app.call("POSMenuPanel", { uniqueKey: "menu-panel" }),
+        app.call("POSOrderPanel", { uniqueKey: "order-panel" }),
+        app.call("POSFooterBar", { uniqueKey: "footer-bar" }),
+        app.call("POSModalsRoot", { uniqueKey: "modals-root" }),
+        app.call("POSToastsRoot", { uniqueKey: "toasts-root" })
+      ]
+    });
+  });
+
+  C.define("POSTopBar", (A, s, app) => {
+    const shift = s.session.shift;
+    const cashier = s.session.cashier;
+    const locale = s.env.locale;
+    const shiftLabel = shift
+      ? `${app.i18n.t("ui.shift")} #${shift.id}`
+      : app.i18n.t("ui.no_shift");
+
+    return A.Header({
+      style: {
+        gridArea: "header",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        padding: "0 20px",
+        borderBottom: "1px solid var(--border-default)",
+        background: "var(--bg-surface)",
+        boxShadow: "0 1px 0 rgba(15,23,42,0.04)"
+      }
+    }, {
+      default: [
+        A.Div({ style: { display: "flex", alignItems: "center", gap: "16px" } }, {
+          default: [
+            A.Div({ style: { fontSize: "22px", fontWeight: 700, color: "var(--primary)" } }, { default: ["Mishkah POS"] }),
+            A.Div({ style: { display: "flex", flexDirection: "column", gap: "2px" } }, {
+              default: [
+                A.Strong({ style: { fontSize: "16px" } }, {
+                  default: [cashier ? cashier.full_name : app.i18n.t("ui.cashier")]
+                }),
+                A.Span({ style: { color: "var(--text-subtle)", fontSize: "12px" } }, { default: [shiftLabel] })
+              ]
+            })
+          ]
+        }),
+        A.Div({ style: { display: "flex", alignItems: "center", gap: "8px" } }, {
+          default: [
+            app.call("Button", {
+              text: app.i18n.t("ui.tables"),
+              variant: "outline",
+              size: "sm",
+              "data-onclick": "view.showTables"
+            }),
+            app.call("Button", {
+              text: app.i18n.t("ui.reports"),
+              variant: "outline",
+              size: "sm",
+              "data-onclick": "view.showReports"
+            }),
+            app.call("Button", {
+              text: "🎨",
+              variant: "ghost",
+              size: "sm",
+              title: app.i18n.t("ui.theme"),
+              "data-onclick": "env.toggleTheme"
+            }),
+            app.call("Button", {
+              text: locale === "ar" ? "EN" : "AR",
+              variant: "ghost",
+              size: "sm",
+              title: app.i18n.t("ui.language"),
+              "data-onclick": "env.toggleLocale"
+            }),
+            app.call("Button", {
+              text: app.i18n.t("ui.logout"),
+              intent: "danger",
+              variant: "ghost",
+              size: "sm",
+              "data-onclick": "session.logout"
+            })
+          ]
+        })
+      ]
+    });
+  });
+
+  const filterMenuItems = (state) => {
+    const locale = state.env.locale || "ar";
+    const search = (state.ui.menu.search || "").trim().toLowerCase();
+    const activeCategory = state.ui.menu.category || "all";
+    return state.catalog.items.filter((item) => {
+      const matchCategory = activeCategory === "all" || item.category === activeCategory;
+      if (!matchCategory) return false;
+      if (!search) return true;
+      const translation = (item.translations && (item.translations[locale] || item.translations.en)) || {};
+      const name = (translation.name || "").toLowerCase();
+      return name.includes(search);
+    });
+  };
+
+  C.define("POSMenuPanel", (A, s, app) => {
+    const categories = s.catalog.categories || [];
+    const locale = s.env.locale || "ar";
+    const activeCategory = s.ui.menu.category || "all";
+    const filteredItems = filterMenuItems(s);
+
+    return A.Div({
+      style: {
+        gridArea: "menu",
+        display: "flex",
+        flexDirection: "column",
+        padding: "16px 20px",
+        gap: "16px",
+        overflow: "hidden"
+      }
+    }, {
+      default: [
+        A.Div({ style: { display: "flex", gap: "8px" } }, {
+          default: [
+            app.call("Input", {
+              placeholder: app.i18n.t("ui.search_placeholder"),
+              value: s.ui.menu.search || "",
+              "data-oninput": "menu.search",
+              style: { flex: "1 1 auto" }
+            })
+          ]
+        }),
+        A.Div({
+          class: "no-scrollbar",
+          style: {
+            display: "flex",
+            gap: "8px",
+            overflowX: "auto",
+            paddingBottom: "4px"
+          }
+        }, {
+          default: categories.map((cat) => {
+            const translation = (cat.translations && (cat.translations[locale] || cat.translations.en)) || {};
+            const isActive = activeCategory === cat.id;
+            return A.Button({
+              type: "button",
+              "data-onclick": "menu.selectCategory",
+              "data-category-id": cat.id,
+              style: {
+                borderRadius: "999px",
+                border: `1px solid ${isActive ? "var(--primary)" : "var(--border-default)"}`,
+                background: isActive ? "var(--primary-soft, rgba(99,102,241,0.12))" : "var(--bg-surface)",
+                color: isActive ? "var(--primary)" : "var(--text-default)",
+                padding: "8px 14px",
+                fontWeight: isActive ? 600 : 500,
+                whiteSpace: "nowrap"
+              }
+            }, { default: [translation.name || cat.id] });
+          })
+        }),
+        A.Div({
+          class: "no-scrollbar",
+          style: {
+            flex: "1 1 auto",
+            overflowY: "auto"
+          }
+        }, {
+          default: filteredItems.length ? A.Div({
             style: {
-                height: '100vh', display: 'grid',
-                gridTemplateRows: '64px 1fr',
-                gridTemplateColumns: 'auto 420px',
-                gridTemplateAreas: '"header header" "menu order"'
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(160px, 1fr))",
+              gap: "16px",
+              paddingBottom: "16px"
             }
-        }, {
-            default: [
-                app.call('POSHeader', { uniqueKey: 'pos-header'}),
-                app.call('MenuPanel', { uniqueKey: 'menu-panel'}),
-                app.call('OrderPanel', { uniqueKey: 'order-panel'}),
-                app.call('TablesModal'),
-                app.call('SettleSheet'),
-                app.call('ReportsSheet'),
-                app.call('ShiftModal')
-            ]
-        });
+          }, {
+            default: filteredItems.map((item) => app.call("POSMenuCard", { item }))
+          }) : app.call("EmptyState", {
+            title: app.i18n.t("ui.empty_menu_title"),
+            text: app.i18n.t("ui.empty_menu_hint")
+          })
+        })
+      ]
     });
+  });
+
+  C.define("POSMenuCard", (A, s, app, p) => {
+    const item = p.item;
+    const locale = s.env.locale || "ar";
+    const translation = (item.translations && (item.translations[locale] || item.translations.en)) || {};
+    const helpers = app.helpers || {};
+    const formatCurrency = helpers.formatCurrency || ((v) => v.toFixed(2));
+    return A.Div({
+      "data-onclick": "order.addItem",
+      "data-item-id": item.id,
+      style: {
+        cursor: "pointer",
+        borderRadius: "20px",
+        overflow: "hidden",
+        border: "1px solid var(--border-default)",
+        background: "var(--bg-surface)",
+        display: "flex",
+        flexDirection: "column",
+        minHeight: "220px",
+        boxShadow: "0 12px 24px -18px rgba(15,23,42,0.4)"
+      }
+    }, {
+      default: [
+        item.image ? A.Img({
+          src: item.image,
+          alt: translation.name || "",
+          style: {
+            width: "100%",
+            height: "120px",
+            objectFit: "cover"
+          }
+        }) : null,
+        A.Div({
+          style: {
+            display: "flex",
+            flexDirection: "column",
+            gap: "8px",
+            padding: "12px"
+          }
+        }, {
+          default: [
+            A.Strong({ style: { fontSize: "15px", minHeight: "40px", display: "block" } }, { default: [translation.name || "—"] }),
+            translation.description ? A.P({ style: { color: "var(--text-subtle)", fontSize: "12px" } }, {
+              default: [translation.description]
+            }) : null,
+            A.Div({ style: { marginTop: "auto", textAlign: "end", fontWeight: 700, color: "var(--primary)" } }, {
+              default: [formatCurrency(item.price, { currency: s.settings.currency })]
+            })
+          ]
+        })
+      ]
+    });
+  });
+
+  C.define("POSOrderPanel", (A, s, app) => {
+    const order = s.order;
+    if (!order) {
+      return A.Div({
+        style: {
+          gridArea: "order",
+          borderLeft: "1px solid var(--border-default)",
+          background: "var(--bg-surface)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center"
+        }
+      }, { default: [app.call("EmptyState", { title: app.i18n.t("ui.no_active_order") })] });
+    }
+
+    return A.Div({
+      style: {
+        gridArea: "order",
+        display: "flex",
+        flexDirection: "column",
+        background: "var(--bg-surface)",
+        borderLeft: "1px solid var(--border-default)",
+        height: "100%"
+      }
+    }, {
+      default: [
+        app.call("POSOrderHeader", { order }),
+        app.call("POSOrderLines", { order }),
+        order.lines.length ? app.call("POSOrderTotals", { order }) : null
+      ]
+    });
+  });
+
+  C.define("POSOrderHeader", (A, s, app, p) => {
+    const order = p.order;
+    const locale = s.env.locale || "ar";
+    const tableNames = (order.tableIds || []).map((tableId) => {
+      const table = s.tables.find((t) => t.id === tableId);
+      return table ? table.name : tableId;
+    });
+
+    const typeItems = [
+      { id: "dine_in", label: app.i18n.t("ui.dine_in") },
+      { id: "takeaway", label: app.i18n.t("ui.takeaway") },
+      { id: "delivery", label: app.i18n.t("ui.delivery") }
+    ];
+
+    return A.Div({
+      style: {
+        padding: "16px",
+        borderBottom: "1px solid var(--border-default)",
+        display: "flex",
+        flexDirection: "column",
+        gap: "12px"
+      }
+    }, {
+      default: [
+        A.Div({ style: { display: "flex", justifyContent: "space-between", alignItems: "center" } }, {
+          default: [
+            A.Div({ style: { fontWeight: 700 } }, { default: [app.i18n.t("ui.current_order")] }),
+            tableNames.length ? A.Div({
+              style: {
+                display: "inline-flex",
+                gap: "8px",
+                alignItems: "center"
+              }
+            }, {
+              default: [
+                A.Span({ style: { color: "var(--text-subtle)", fontSize: "12px" } }, { default: [app.i18n.t("ui.table")] }),
+                A.Span({ style: { fontWeight: 600 } }, { default: [tableNames.join(", ")] })
+              ]
+            }) : null
+          ]
+        }),
+        A.Div({ style: { display: "flex", gap: "8px" } }, {
+          default: typeItems.map((item) => A.Button({
+            type: "button",
+            "data-onclick": "order.setType",
+            "data-type": item.id,
+            style: {
+              flex: "1 1 auto",
+              padding: "10px 12px",
+              borderRadius: "14px",
+              border: `1px solid ${order.type === item.id ? "var(--primary)" : "var(--border-default)"}`,
+              background: order.type === item.id ? "var(--primary-soft, rgba(99,102,241,0.16))" : "var(--bg-page)",
+              fontWeight: order.type === item.id ? 600 : 500
+            }
+          }, { default: [item.label] }))
+        })
+      ]
+    });
+  });
+
+  C.define("POSOrderLines", (A, s, app, p) => {
+    const order = p.order;
+    if (!order.lines.length) {
+      return A.Div({
+        class: "no-scrollbar",
+        style: {
+          flex: "1 1 auto",
+          overflowY: "auto",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: "24px"
+        }
+      }, { default: [app.call("EmptyState", { title: app.i18n.t("ui.empty_order"), text: app.i18n.t("ui.empty_order_hint") })] });
+    }
+
+    return A.Div({
+      class: "no-scrollbar",
+      style: {
+        flex: "1 1 auto",
+        overflowY: "auto",
+        padding: "12px 16px",
+        display: "flex",
+        flexDirection: "column",
+        gap: "12px"
+      }
+    }, {
+      default: order.lines.map((line) => app.call("POSOrderLine", { line }))
+    });
+  });
+
+  C.define("POSOrderLine", (A, s, app, p) => {
+    const line = p.line;
+    const helpers = app.helpers || {};
+    const formatCurrency = helpers.formatCurrency || ((v) => v.toFixed(2));
+    return A.Div({
+      style: {
+        borderRadius: "16px",
+        border: "1px solid var(--border-default)",
+        padding: "12px",
+        display: "grid",
+        gridTemplateColumns: "1fr auto",
+        gap: "12px",
+        background: "var(--bg-page)"
+      }
+    }, {
+      default: [
+        A.Div({ style: { display: "flex", flexDirection: "column", gap: "4px" } }, {
+          default: [
+            A.Div({ style: { display: "flex", alignItems: "center", justifyContent: "space-between", gap: "8px" } }, {
+              default: [
+                A.Strong({}, { default: [line.name] }),
+                A.Span({ style: { fontWeight: 700, color: "var(--primary)" } }, { default: [formatCurrency(line.total)] })
+              ]
+            }),
+            line.notes ? A.Div({ style: { fontSize: "12px", color: "var(--text-subtle)" } }, { default: [line.notes] }) : null,
+            line.modifiers && line.modifiers.length ? A.Div({ style: { fontSize: "12px", color: "var(--text-subtle)" } }, {
+              default: [line.modifiers.join(", ")]
+            }) : null
+          ]
+        }),
+        A.Div({ style: { display: "flex", flexDirection: "column", alignItems: "flex-end", gap: "8px" } }, {
+          default: [
+            A.Div({ style: { display: "inline-flex", alignItems: "center", gap: "6px" } }, {
+              default: [
+                app.call("Button", {
+                  text: "−",
+                  variant: "ghost",
+                  size: "sm",
+                  style: { minWidth: "36px", height: "36px", borderRadius: "12px" },
+                  "data-onclick": "order.decrementLine",
+                  "data-line-id": line.id
+                }),
+                A.Span({ style: { minWidth: "32px", textAlign: "center", fontWeight: 600 } }, { default: [line.qty] }),
+                app.call("Button", {
+                  text: "+",
+                  variant: "ghost",
+                  size: "sm",
+                  style: { minWidth: "36px", height: "36px", borderRadius: "12px" },
+                  "data-onclick": "order.incrementLine",
+                  "data-line-id": line.id
+                })
+              ]
+            }),
+            app.call("Button", {
+              text: app.i18n.t("ui.remove"),
+              variant: "ghost",
+              intent: "danger",
+              size: "xs",
+              "data-onclick": "order.removeLine",
+              "data-line-id": line.id
+            })
+          ]
+        })
+      ]
+    });
+  });
+
+  C.define("POSOrderTotals", (A, s, app, p) => {
+    const order = p.order;
+    const totals = order.totals;
+    const helpers = app.helpers || {};
+    const f = helpers.formatCurrency || ((v) => v.toFixed(2));
+    return A.Div({
+      style: {
+        borderTop: "1px solid var(--border-default)",
+        padding: "16px",
+        display: "flex",
+        flexDirection: "column",
+        gap: "8px"
+      }
+    }, {
+      default: [
+        A.Div({ style: { display: "flex", justifyContent: "space-between", fontSize: "14px", color: "var(--text-subtle)" } }, {
+          default: [A.Span({}, { default: [app.i18n.t("ui.subtotal")] }), A.Span({}, { default: [f(totals.subtotal)] })]
+        }),
+        A.Div({ style: { display: "flex", justifyContent: "space-between", fontSize: "14px", color: "var(--text-subtle)" } }, {
+          default: [A.Span({}, { default: [app.i18n.t("ui.service")] }), A.Span({}, { default: [f(totals.service)] })]
+        }),
+        A.Div({ style: { display: "flex", justifyContent: "space-between", fontSize: "14px", color: "var(--text-subtle)" } }, {
+          default: [A.Span({}, { default: [app.i18n.t("ui.vat")] }), A.Span({}, { default: [f(totals.vat)] })]
+        }),
+        A.Div({
+          style: {
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            fontWeight: 700,
+            fontSize: "20px",
+            marginTop: "8px"
+          }
+        }, {
+          default: [A.Span({}, { default: [app.i18n.t("ui.total")] }), A.Span({}, { default: [f(totals.total)] })]
+        })
+      ]
+    });
+  });
+
+  C.define("POSFooterBar", (A, s, app) => {
+    const order = s.order;
+    const helpers = app.helpers || {};
+    const f = helpers.formatCurrency || ((v) => v.toFixed(2));
+    const splits = s.payments.splits || [];
+    const paid = splits.reduce((sum, split) => sum + (split.amount || 0), 0);
+    const total = order ? order.totals.total : 0;
+    const remaining = Math.max(0, total - paid);
+
+    return A.Div({
+      style: {
+        gridArea: "footer",
+        background: "var(--bg-surface)",
+        borderTop: "1px solid var(--border-default)",
+        display: "grid",
+        gridTemplateColumns: "1fr clamp(240px, 30vw, 360px)",
+        alignItems: "center",
+        padding: "0 20px"
+      }
+    }, {
+      default: [
+        A.Div({ style: { display: "flex", alignItems: "center", gap: "18px" } }, {
+          default: [
+            A.Div({ style: { display: "flex", flexDirection: "column", gap: "2px" } }, {
+              default: [
+                A.Span({ style: { color: "var(--text-subtle)", fontSize: "12px" } }, { default: [app.i18n.t("ui.total")] }),
+                A.Strong({ style: { fontSize: "20px" } }, { default: [f(total)] })
+              ]
+            }),
+            A.Div({ style: { display: "flex", flexDirection: "column", gap: "2px" } }, {
+              default: [
+                A.Span({ style: { color: "var(--text-subtle)", fontSize: "12px" } }, { default: [app.i18n.t("ui.remaining")] }),
+                A.Strong({ style: { fontSize: "20px", color: remaining === 0 ? "var(--success)" : "var(--danger)" } }, {
+                  default: [f(remaining)]
+                })
+              ]
+            })
+          ]
+        }),
+        A.Div({ style: { display: "flex", justifyContent: "flex-end", gap: "12px" } }, {
+          default: [
+            app.call("Button", {
+              text: app.i18n.t("ui.clear_order"),
+              variant: "ghost",
+              size: "sm",
+              "data-onclick": "order.clear"
+            }),
+            app.call("Button", {
+              text: app.i18n.t("ui.park_order"),
+              variant: "outline",
+              size: "sm",
+              "data-onclick": "order.park"
+            }),
+            app.call("Button", {
+              text: app.i18n.t("ui.settle_pay"),
+              intent: "success",
+              size: "lg",
+              style: { minWidth: "160px", height: "52px", fontSize: "18px" },
+              "data-onclick": "payments.open"
+            })
+          ]
+        })
+      ]
+    });
+  });
+
+  C.define("POSModalsRoot", (A, s, app) => {
+    const active = s.ui.overlays.active;
+    return A.Div({
+      style: {
+        position: "fixed",
+        inset: 0,
+        zIndex: 1200,
+        pointerEvents: active ? "auto" : "none"
+      }
+    }, {
+      default: [
+        app.call("POSTablesModal", { open: active === "tables" }),
+        app.call("POSPaymentsSheet", { open: active === "payments" }),
+        app.call("POSReportsSheet", { open: active === "reports" }),
+        app.call("POSShiftSummaryModal", { open: active === "shift-summary" })
+      ]
+    });
+  });
+
+  C.define("POSTablesModal", (A, s, app, p) => {
+    if (!p.open) return null;
+    return app.call("Modal", {
+      open: true,
+      size: "lg",
+      title: app.i18n.t("ui.tables"),
+      onClose: () => app.dispatch("view.closeOverlay")
+    }, {
+      body: [
+        A.Div({
+          class: "no-scrollbar",
+          style: {
+            maxHeight: "70vh",
+            overflowY: "auto",
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fill, minmax(160px, 1fr))",
+            gap: "12px"
+          }
+        }, {
+          default: (s.tables || []).map((table) => app.call("POSTableCard", { table }))
+        })
+      ]
+    });
+  });
+
+  C.define("POSTableCard", (A, s, app, p) => {
+    const table = p.table;
+    const statusColors = {
+      available: "var(--success)",
+      occupied: "var(--danger)",
+      reserved: "var(--warning, #f59e0b)",
+      offline: "#4b5563"
+    };
+    const badgeColor = statusColors[table.status] || "var(--text-default)";
+    return A.Div({
+      "data-onclick": "tables.attach",
+      "data-table-id": table.id,
+      style: {
+        borderRadius: "16px",
+        border: `2px solid ${badgeColor}`,
+        background: "var(--bg-surface)",
+        padding: "16px",
+        display: "flex",
+        flexDirection: "column",
+        gap: "8px",
+        cursor: "pointer"
+      }
+    }, {
+      default: [
+        A.Strong({ style: { fontSize: "18px" } }, { default: [table.name] }),
+        A.Span({ style: { color: "var(--text-subtle)", fontSize: "12px" } }, {
+          default: [`${table.seats} ${app.i18n.t("ui.seats")}`]
+        }),
+        A.Span({ style: { fontSize: "12px", color: badgeColor } }, { default: [app.i18n.t(`ui.table_status_${table.status}`)] })
+      ]
+    });
+  });
+
+  C.define("POSPaymentsSheet", (A, s, app, p) => {
+    if (!p.open) return null;
+    const helpers = app.helpers || {};
+    const f = helpers.formatCurrency || ((v) => v.toFixed(2));
+    const order = s.order;
+    const total = order ? order.totals.total : 0;
+    const splits = s.payments.splits || [];
+    const paid = splits.reduce((sum, split) => sum + (split.amount || 0), 0);
+    const due = Math.max(0, total - paid);
+
+    return app.call("Sheet", {
+      open: true,
+      side: "end",
+      title: app.i18n.t("ui.settle_pay"),
+      size: "md",
+      onClose: () => app.dispatch("payments.close")
+    }, {
+      body: [
+        A.Div({ style: { display: "flex", flexDirection: "column", gap: "16px" } }, {
+          default: [
+            A.Div({ style: { textAlign: "center" } }, {
+              default: [
+                A.Span({ style: { display: "block", color: "var(--text-subtle)" } }, { default: [app.i18n.t("ui.total")] }),
+                A.Strong({ style: { fontSize: "28px" } }, { default: [f(total)] }),
+                A.Span({ style: { display: "block", marginTop: "8px", color: due === 0 ? "var(--success)" : "var(--danger)" } }, {
+                  default: [due === 0 ? app.i18n.t("ui.paid_in_full") : `${app.i18n.t("ui.remaining")}: ${f(due)}`]
+                })
+              ]
+            }),
+            app.call("POSPaymentMethods", { current: s.payments.method || "cash" }),
+            app.call("POSPaymentAmountPad", {
+              buffer: s.payments.buffer || "0",
+              confirmDisabled: due === 0,
+              due
+            }),
+            splits.length ? A.Div({ style: { borderTop: "1px solid var(--border-default)", paddingTop: "12px" } }, {
+              default: [
+                A.Div({ style: { fontWeight: 600, marginBottom: "8px" } }, { default: [app.i18n.t("ui.splits")] }),
+                A.Div({ style: { display: "flex", flexDirection: "column", gap: "8px" } }, {
+                  default: splits.map((split) => A.Div({
+                    style: {
+                      display: "flex",
+                      justifyContent: "space-between",
+                      alignItems: "center",
+                      borderRadius: "12px",
+                      background: "var(--bg-page)",
+                      padding: "8px 12px"
+                    }
+                  }, {
+                    default: [
+                      A.Span({}, { default: [app.i18n.t(`ui.pay_method_${split.method}`)] }),
+                      A.Div({ style: { display: "flex", gap: "8px", alignItems: "center" } }, {
+                        default: [
+                          A.Strong({}, { default: [f(split.amount)] }),
+                          app.call("Button", {
+                            text: app.i18n.t("ui.remove"),
+                            variant: "ghost",
+                            size: "xs",
+                            "data-onclick": "payments.removeSplit",
+                            "data-split-id": split.id
+                          })
+                        ]
+                      })
+                    ]
+                  }))
+                })
+              ]
+            }) : null
+          ]
+        })
+      ],
+      footer: [
+        app.call("Button", {
+          text: app.i18n.t("ui.complete_payment"),
+          intent: "success",
+          disabled: due > 0,
+          "data-onclick": "payments.complete"
+        })
+      ]
+    });
+  });
+
+  C.define("POSPaymentMethods", (A, s, app, p) => {
+    const methods = [
+      { id: "cash", label: app.i18n.t("ui.cash") },
+      { id: "card", label: app.i18n.t("ui.card") },
+      { id: "wallet", label: app.i18n.t("ui.wallet") }
+    ];
+    return A.Div({
+      style: {
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fit, minmax(120px, 1fr))",
+        gap: "8px"
+      }
+    }, {
+      default: methods.map((method) => A.Button({
+        type: "button",
+        "data-onclick": "payments.setMethod",
+        "data-method": method.id,
+        style: {
+          borderRadius: "14px",
+          border: `1px solid ${p.current === method.id ? "var(--primary)" : "var(--border-default)"}`,
+          padding: "10px",
+          background: p.current === method.id ? "var(--primary-soft, rgba(99,102,241,0.18))" : "var(--bg-page)"
+        }
+      }, { default: [method.label] }))
+    });
+  });
+
+  C.define("POSPaymentAmountPad", (A, s, app, p) => {
+    const buffer = p.buffer || "0";
+    const keys = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", ".", "⌫"];
+    return A.Div({
+      style: {
+        display: "flex",
+        flexDirection: "column",
+        gap: "12px"
+      }
+    }, {
+      default: [
+        A.Div({
+          style: {
+            borderRadius: "16px",
+            border: "1px solid var(--border-default)",
+            padding: "12px",
+            fontSize: "24px",
+            textAlign: "center",
+            background: "var(--bg-page)",
+            fontWeight: 600
+          }
+        }, { default: [buffer] }),
+        A.Div({
+          style: {
+            display: "grid",
+            gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+            gap: "8px"
+          }
+        }, {
+          default: keys.map((key) => app.call("Button", {
+            text: key,
+            variant: "ghost",
+            style: { height: "52px", borderRadius: "16px", fontSize: "18px" },
+            "data-onclick": "payments.key",
+            "data-key": key
+          }))
+        }),
+        A.Div({ style: { display: "grid", gridTemplateColumns: "repeat(2, minmax(0, 1fr))", gap: "8px" } }, {
+          default: [
+            app.call("Button", {
+              text: app.i18n.t("ui.clear"),
+              variant: "outline",
+              "data-onclick": "payments.clearBuffer"
+            }),
+            app.call("Button", {
+              text: app.i18n.t("ui.add_split"),
+              intent: "primary",
+              disabled: p.due <= 0,
+              "data-onclick": "payments.addSplit"
+            })
+          ]
+        })
+      ]
+    });
+  });
+
+  C.define("POSShiftSummaryModal", (A, s, app, p) => {
+    if (!p.open) return null;
+    const shift = s.session.shift;
+    const helpers = app.helpers || {};
+    const f = helpers.formatCurrency || ((v) => v.toFixed(2));
+    return app.call("Modal", {
+      open: true,
+      size: "sm",
+      title: app.i18n.t("ui.shift_summary"),
+      onClose: () => app.dispatch("view.closeOverlay")
+    }, {
+      body: [
+        shift ? app.call("DescriptionList", {
+          items: [
+            { term: app.i18n.t("ui.shift"), details: `#${shift.id}` },
+            { term: app.i18n.t("ui.start_time"), details: shift.startedAt || "—" },
+            { term: app.i18n.t("ui.opening_float"), details: f(shift.openingFloat || 0) },
+            { term: app.i18n.t("ui.orders_count"), details: (shift.orderIds || []).length }
+          ]
+        }) : app.call("EmptyState", { title: app.i18n.t("ui.no_shift") })
+      ],
+      footer: [
+        app.call("Button", {
+          text: app.i18n.t("ui.close_shift"),
+          intent: "danger",
+          "data-onclick": "shift.close"
+        })
+      ]
+    });
+  });
+
+  C.define("POSReportsSheet", (A, s, app, p) => {
+    if (!p.open) return null;
+    return app.call("Sheet", {
+      open: true,
+      side: "start",
+      size: "lg",
+      title: app.i18n.t("ui.reports"),
+      onClose: () => app.dispatch("view.closeOverlay")
+    }, {
+      body: [
+        app.call("EmptyState", { title: app.i18n.t("ui.reports_placeholder"), text: app.i18n.t("ui.reports_placeholder_hint") })
+      ]
+    });
+  });
+
+  C.define("POSToastsRoot", (A, s, app) => {
+    const toasts = s.ui.toasts || [];
+    if (!toasts.length) return null;
+    return A.Div({
+      style: {
+        position: "fixed",
+        insetInlineEnd: "20px",
+        insetBlockStart: "20px",
+        display: "flex",
+        flexDirection: "column",
+        gap: "12px",
+        zIndex: 1500
+      }
+    }, {
+      default: toasts.map((toast) => A.Div({
+        style: {
+          borderRadius: "14px",
+          background: "var(--bg-surface)",
+          boxShadow: "0 12px 24px -16px rgba(15,23,42,0.32)",
+          padding: "12px 16px",
+          minWidth: "240px",
+          borderInlineStart: `4px solid ${toast.intent === "success" ? "var(--success)" : toast.intent === "danger" ? "var(--danger)" : "var(--primary)"}`
+        }
+      }, {
+        default: [
+          A.Div({ style: { display: "flex", justifyContent: "space-between", alignItems: "center", gap: "12px" } }, {
+            default: [
+              A.Div({ style: { display: "flex", flexDirection: "column", gap: "4px" } }, {
+                default: [
+                  toast.title ? A.Strong({}, { default: [toast.title] }) : null,
+                  toast.message ? A.Span({ style: { color: "var(--text-subtle)", fontSize: "12px" } }, { default: [toast.message] }) : null
+                ]
+              }),
+              app.call("Button", {
+                text: "×",
+                variant: "ghost",
+                size: "xs",
+                "data-onclick": "ui.dismissToast",
+                "data-toast-id": toast.id
+              })
+            ]
+          })
+        ]
+      }))
+    });
+  });
 
 })(window);
-

--- a/pos.html
+++ b/pos.html
@@ -2,20 +2,41 @@
 <html lang="ar" dir="rtl" data-theme="light">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Mishkah v5 — POS</title>
-  <link rel="stylesheet" href="./mishkah-theme-v5.css" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Mishkah POS v5</title>
+  <script>
+    window.tailwind = window.tailwind || {};
+    window.tailwind.config = {
+      corePlugins: { preflight: false },
+      theme: { extend: {} }
+    };
+  </script>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="./mishkah-theme-v5.css" />
   <style>
-    html,body,#app{height:100%}body{font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Ubuntu,'Helvetica Neue',Arial,sans-serif;background:var(--bg-page);color:var(--text-default)}
+    :root {
+      color-scheme: light;
+    }
+    html, body {
+      height: 100%;
+      margin: 0;
+      background: var(--bg-page);
+      color: var(--text-default);
+      font-family: var(--font-sans, system-ui, -apple-system, 'Segoe UI', sans-serif);
+    }
+    #app {
+      min-height: 100%;
+    }
+    .no-scrollbar {
+      scrollbar-width: none;
+    }
+    .no-scrollbar::-webkit-scrollbar {
+      display: none;
+    }
   </style>
 </head>
 <body>
   <div id="app"></div>
-<script>
-(function(g){
-  })(window);
-</script>
 
   <script src="./mishkah-utils-v5.js"></script>
   <script src="./mishkah-engines-v5.js"></script>

--- a/pos.js
+++ b/pos.js
@@ -1,337 +1,613 @@
 (function (window) {
-    "use strict";
-    const { Core } = window.Mishkah;
+  "use strict";
 
-    const calculateTotals = (lines, settings) => {
-        const subtotal = lines.reduce((acc, line) => acc + (line.total || 0), 0);
-        const service = subtotal * (settings.service_charge_rate || 0);
-        const vat = (subtotal + service) * (settings.tax_rate || 0);
-        const grand = subtotal + service + vat;
-        return { subtotal, service, vat, grand };
+  const M = window.Mishkah || {};
+  const Core = M.Core;
+  const utils = M.utils || {};
+  if (!Core) return;
+
+  const db = window.database || {};
+  const clone = (value) => (value ? JSON.parse(JSON.stringify(value)) : value);
+  const round = (value) => Math.round((Number(value) + Number.EPSILON) * 100) / 100;
+  const nextId = (prefix) => (utils.uid ? utils.uid(prefix) : `${prefix}-${Math.random().toString(36).slice(2, 9)}`);
+
+  const baseSettings = clone(db.settings) || {
+    tax_rate: 0.14,
+    service_charge_rate: 0.12,
+    currency: { ar: "ج.م", en: "EGP" }
+  };
+
+  function translateItem(item, locale) {
+    if (!item) return { name: "—", description: "" };
+    const byLocale = (item.translations && (item.translations[locale] || item.translations.en)) || {};
+    return { name: byLocale.name || item.name || String(item.id), description: byLocale.description || "" };
+  }
+
+  function createOrder(type = "dine_in") {
+    return {
+      id: nextId("ord"),
+      type,
+      status: "draft",
+      createdAt: new Date().toISOString(),
+      tableIds: [],
+      guestCount: 1,
+      lines: [],
+      totals: { subtotal: 0, service: 0, vat: 0, total: 0 },
+      payments: []
     };
+  }
 
-    const createOrder = (type = 'dine_in') => ({
-        id: `ord-${Date.now()}`,
-        type,
-        lines: [],
-        totals: { subtotal: 0, service: 0, vat: 0, grand: 0 },
-        tableId: null,
-        customerId: null,
-        status: 'new'
+  function computeTotals(lines, settings) {
+    const subtotal = round((lines || []).reduce((acc, line) => acc + round((line.price || 0) * (line.qty || 0)), 0));
+    const serviceRate = settings.service_charge_rate || 0;
+    const taxRate = settings.tax_rate || 0;
+    const service = round(subtotal * serviceRate);
+    const vat = round((subtotal + service) * taxRate);
+    const total = round(subtotal + service + vat);
+    return { subtotal, service, vat, total };
+  }
+
+  function ensureOrder(state, type) {
+    if (!state.order) {
+      state.order = createOrder(type || "dine_in");
+    }
+    return state.order;
+  }
+
+  function getDue(state) {
+    if (!state.order) return 0;
+    const total = state.order.totals.total || 0;
+    const paid = (state.payments.splits || []).reduce((sum, split) => sum + (split.amount || 0), 0);
+    return round(Math.max(0, total - paid));
+  }
+
+  function translateKey(key, locale) {
+    const section = dictionaries.ui || {};
+    const entry = section[key];
+    if (!entry) return key;
+    return entry[locale] || entry.en || Object.values(entry)[0] || key;
+  }
+
+  function pushToast(truth, payload) {
+    const id = nextId("toast");
+    truth.produce((state) => {
+      state.ui.toasts = state.ui.toasts || [];
+      state.ui.toasts.push({ id, timeout: 3200, intent: "primary", ...payload });
     });
+    truth.mark("toasts-root");
+    const timeout = (payload && payload.timeout) || 3200;
+    setTimeout(() => {
+      truth.produce((state) => {
+        const list = state.ui.toasts || [];
+        const idx = list.findIndex((t) => t.id === id);
+        if (idx >= 0) list.splice(idx, 1);
+      });
+      truth.mark("toasts-root");
+    }, timeout);
+  }
 
-    const commands = {
-        updateLoginPin: ({ truth }, e, el) => {
-            const key = el.dataset.key;
-            truth.produce(s => {
-                if (key === '⌫') {
-                    s.ui.loginPin = s.ui.loginPin.slice(0, -1);
-                } else if (s.ui.loginPin.length < 4 && key !== '.') {
-                    s.ui.loginPin += key;
-                }
-            });
-            truth.mark('login-screen');
-        },
-        clearLoginPin: ({ truth }) => {
-            truth.produce(s => { s.ui.loginPin = ''; });
-            truth.mark('login-screen');
-        },
-        attemptLogin: ({ truth }) => {
-            truth.produce(s => {
-                const employee = s.employees.find(e => e.pin_code === s.ui.loginPin);
-                if (employee) {
-                    s.session.cashier = employee;
-                    s.ui.view = 'shift';
-                    s.ui.loginPin = '';
-                    s.ui.loginError = null;
-                } else {
-                    s.ui.loginError = 'PIN غير صحيح';
-                    s.ui.loginPin = '';
-                }
-            });
-            truth.rebuildAll();
-        },
-        logout: ({ truth }) => {
-            truth.produce(s => {
-                s.session.cashier = null;
-                s.session.shift = null;
-                s.ui.view = 'login';
-            });
-            truth.rebuildAll();
-        },
-        openShift: ({ truth }) => {
-            truth.produce(s => {
-                s.session.shift = {
-                    id: Date.now().toString().slice(-6),
-                    startTime: new Date().toISOString(),
-                    openingFloat: s.ui.openingFloat || 0,
-                    orders: []
-                };
-                s.order = createOrder();
-                s.ui.view = 'pos';
-            });
-            truth.rebuildAll();
-        },
-        closeShift: ({ truth }) => {
-            truth.produce(s => {
-                s.session.cashier = null;
-                s.session.shift = null;
-                s.ui.view = 'login';
-            });
-            truth.rebuildAll();
-        },
-        updateOpeningFloat: ({ truth }, e) => {
-            truth.produce(s => { s.ui.openingFloat = parseFloat(e.target.value) || 0; });
-            truth.mark('pos-root');
-        },
-        selectCategory: ({ truth }, e, el) => {
-            const categoryId = el.dataset.id;
-            truth.produce(s => { s.env.currentCategory = categoryId; });
-            truth.mark('menu-panel');
-        },
-        setSearchQuery: ({ truth }, e) => {
-            truth.produce(s => { s.env.searchQuery = e.target.value; });
-            truth.mark('menu-panel');
-        },
-        addToOrder: ({ truth }, e, el) => {
-            const itemId = el.dataset.itemId;
-            truth.produce(s => {
-                if (!s.order) s.order = createOrder();
-                const itemData = s.catalog.items.find(i => i.id == itemId);
-                if (!itemData) return;
-                
-                const locale = s.env.locale || 'ar';
-                const existingLine = s.order.lines.find(line => line.itemId == itemId && !line.mods);
-                if (existingLine) {
-                    existingLine.qty++;
-                    existingLine.total = existingLine.price * existingLine.qty;
-                } else {
-                    s.order.lines.push({
-                        id: `${itemId}-${Date.now()}`,
-                        itemId: itemData.id,
-                        name: (itemData.translations[locale] || itemData.translations.en).name,
-                        qty: 1,
-                        price: itemData.price,
-                        total: itemData.price,
-                        mods: null
-                    });
-                }
-                s.order.totals = calculateTotals(s.order.lines, s.settings);
-            });
-            truth.mark('order-panel');
-        },
-        removeOrderLine: ({ truth }, e, el) => {
-            const index = parseInt(el.dataset.index, 10);
-            truth.produce(s => {
-                if (!s.order || !s.order.lines[index]) return;
-                s.order.lines.splice(index, 1);
-                s.order.totals = calculateTotals(s.order.lines, s.settings);
-            });
-            truth.mark('order-panel');
-        },
-        increaseLineQty: ({ truth }, e, el) => {
-            const index = parseInt(el.dataset.index, 10);
-            truth.produce(s => {
-                const line = s.order.lines[index];
-                if (line) {
-                    line.qty++;
-                    line.total = line.price * line.qty;
-                    s.order.totals = calculateTotals(s.order.lines, s.settings);
-                }
-            });
-            truth.mark('order-panel');
-        },
-        decreaseLineQty: ({ truth }, e, el) => {
-            const index = parseInt(el.dataset.index, 10);
-            truth.produce(s => {
-                const line = s.order.lines[index];
-                if (line) {
-                    line.qty = Math.max(0, line.qty - 1);
-                    if (line.qty === 0) {
-                        s.order.lines.splice(index, 1);
-                    } else {
-                        line.total = line.price * line.qty;
-                    }
-                    s.order.totals = calculateTotals(s.order.lines, s.settings);
-                }
-            });
-            truth.mark('order-panel');
-        },
-        parkOrder: ({ truth }) => {
-            truth.produce(s => {
-                if (s.order && s.order.lines.length > 0) {
-                    s.parkedOrders.push(s.order);
-                    s.order = createOrder(s.order.type);
-                }
-            });
-            truth.mark('order-panel');
-        },
-        showPosView: ({ truth }) => { 
-            truth.produce(s => { s.ui.view = 'pos'; });
-            truth.rebuildAll();
-        },
-        showTables: ({ truth }) => { 
-            truth.produce(s => { s.ui.view = 'tables'; });
-            truth.rebuildAll();
-        },
-        showReports: ({ truth }) => { 
-            truth.produce(s => { s.ui.view = 'reports'; });
-            truth.rebuildAll();
-        },
-        openSettleSheet: ({ truth }) => { 
-            truth.produce(s => { s.ui.view = 'settle'; });
-            truth.rebuildAll();
-        },
-        selectTable: ({ truth }, e, el) => {
-            const tableId = el.dataset.id;
-            truth.produce(s => {
-                if (!s.order) s.order = createOrder();
-                s.order.tableId = tableId;
-                s.ui.view = 'pos';
-            });
-            truth.rebuildAll();
-        },
-        updatePaymentAmount: ({ truth }, e, el) => {
-            const key = el.dataset.key;
-            truth.produce(s => {
-                let current = String(s.ui.payment.amount || '0');
-                if (key === '⌫') {
-                    current = current.length > 1 ? current.slice(0, -1) : '0';
-                } else if (key === '.' && !current.includes('.')) {
-                    current += '.';
-                } else if (key !== '.') {
-                    current = current === '0' ? key : current + key;
-                }
-                s.ui.payment.amount = parseFloat(current);
-            });
-            truth.mark('pos-root');
-        },
-        clearPaymentAmount: ({ truth }) => {
-            truth.produce(s => { s.ui.payment.amount = 0; });
-            truth.mark('pos-root');
-        },
-        finalizeOrder: ({ truth }) => {
-            truth.produce(s => {
-                if (s.order && s.order.lines.length > 0) {
-                    const finalOrder = {
-                        ...s.order,
-                        status: 'paid',
-                        paidAt: new Date().toISOString(),
-                        cashier: s.session.cashier
-                    };
-                    s.history.closedOrders.push(finalOrder);
-                    s.order = createOrder(s.order.type);
-                    s.ui.payment.amount = 0;
-                    s.ui.view = 'pos';
-                }
-            });
-            truth.rebuildAll();
-        },
-        toggleTheme: ({ env }) => env.toggleTheme(),
-        switchLanguage: ({ env }) => {
-             const newLocale = env.get().locale === 'ar' ? 'en' : 'ar';
-             env.setLocale(newLocale);
-        },
-    };
+  function notify(truth, key, intent = "primary") {
+    const locale = truth.get().env.locale || "ar";
+    pushToast(truth, { title: "POS", message: translateKey(key, locale), intent });
+  }
 
-    const app = Core.createApp({
-        mount: '#app',
-        rootComponent: 'POSRoot',
-        locale: 'ar',
-        dir: 'auto',
-        theme: 'auto',
-        persistEnv: true,
-        dictionaries: {
-            ui: {
-                welcome: { en: 'Welcome', ar: 'أهلاً بك' },
-                enterPin: { en: 'Enter your PIN to continue', ar: 'أدخل رقم التعريف الشخصي للمتابعة' },
-                login: { en: 'Login', ar: 'دخول' },
-                logout: { en: 'Logout', ar: 'خروج' },
-                tables: { en: 'Tables', ar: 'الطاولات' },
-                reports: { en: 'Reports', ar: 'التقارير' },
-                shift: { en: 'Shift', ar: 'الوردية' },
-                noShift: { en: 'No Active Shift', ar: 'لا توجد وردية نشطة' },
-                searchItems: { en: 'Search items...', ar: 'ابحث عن الأصناف...' },
-                emptyOrder: { en: 'Empty Order', ar: 'الطلب فارغ' },
-                selectItems: { en: 'Select items to start', ar: 'اختر أصنافاً للبدء' },
-                dine_in: { en: 'Dine-in', ar: 'صالة' },
-                takeaway: { en: 'Takeaway', ar: 'سفري' },
-                delivery: { en: 'Delivery', ar: 'توصيل' },
-                subtotal: { en: 'Subtotal', ar: 'المجموع الفرعي' },
-                service: { en: 'Service', ar: 'خدمة' },
-                vat: { en: 'VAT', ar: 'ضريبة القيمة المضافة' },
-                grandTotal: { en: 'Total', ar: 'الإجمالي' },
-                parkOrder: { en: 'Park Order', ar: 'تعليق الطلب' },
-                settle: { en: 'Settle', ar: 'تحصيل' },
-                clear: { en: 'C', ar: 'مسح' },
-                confirm: { en: 'Confirm', ar: 'تأكيد' },
-                select_table: { en: 'Select Table', ar: 'اختر طاولة' },
-                seats: { en: 'seats', ar: 'مقاعد' },
-                settlePayment: { en: 'Settle Payment', ar: 'تحصيل الدفعة' },
-                totalDue: { en: 'Total Due', ar: 'المبلغ المستحق' },
-                payCash: { en: 'Pay Cash', ar: 'دفع نقدي' },
-                openShift: {en: 'Open Shift', ar: 'فتح وردية'},
-                closeShift: {en: 'Close Shift', ar: 'إغلاق وردية'},
-                openingFloat: {en: 'Opening Float', ar: 'رصيد الافتتاح'},
-                startTime: {en: 'Start Time', ar: 'وقت البدء'},
-                cashSales: {en: 'Cash Sales', ar: 'مبيعات نقدية'},
-                expectedCash: {en: 'Expected in Drawer', ar: 'المتوقع بالدرج'},
-                type: {en: 'Type', ar: 'النوع'},
-                total: {en: 'Total', ar: 'المجموع'},
-                cashier: {en: 'Cashier', ar: 'الكاشير'},
-            }
-        },
-        initial: {
-            settings: window.database.settings,
-            catalog: {
-                items: window.database.items,
-                categories: window.database.categories,
-                modifiers: window.database.modifiers
-            },
-            employees: window.database.employees,
-            tables: window.database.tables,
-            session: { cashier: null, shift: null },
-            order: null,
-            parkedOrders: [],
-            history: { closedOrders: [] },
-            ui: {
-                view: 'login',
-                loginPin: '',
-                loginError: null,
-                payment: { amount: 0, method: 'cash' },
-                openingFloat: 0
-            },
-            env: {
-                locale: 'ar',
-                currentCategory: 'all',
-                searchQuery: ''
-            }
-        },
-        commands,helpers: {
-            formatCurrency: (amount, locale, currency = 'EGP') => {
-                // 'app' غير ضروري هنا لأننا نمرر locale الصحيح
-                const loc = locale || 'ar'; // يمكنك وضع قيمة افتراضية
-                const val = typeof amount === 'number' ? amount : 0;
-                return new Intl.NumberFormat(loc, { style: 'currency', currency, currencyDisplay: 'symbol' }).format(val);
-            }
+  const initialState = {
+    env: {
+      locale: "ar",
+      dir: "rtl",
+      theme: "light"
+    },
+    ui: {
+      stage: "login",
+      login: { pin: "", error: null },
+      shift: { openingFloat: "" },
+      menu: { category: "all", search: "" },
+      overlays: { active: null, payload: null },
+      toasts: []
+    },
+    session: {
+      cashier: null,
+      shift: null
+    },
+    settings: baseSettings,
+    catalog: {
+      categories: clone(db.categories) || [{ id: "all", translations: { ar: "الكل", en: "All" } }],
+      items: clone(db.items) || []
+    },
+    modifiers: clone(db.modifiers) || {},
+    tables: clone(db.tables) || [],
+    drivers: clone(db.drivers) || [],
+    reservations: clone(db.reservations) || [],
+    order: null,
+    parkedOrders: [],
+    completedOrders: [],
+    payments: {
+      method: "cash",
+      buffer: "0",
+      splits: []
+    }
+  };
+
+  const dictionaries = {
+    ui: {
+      welcome: { ar: "مرحباً بك", en: "Welcome" },
+      enter_pin: { ar: "أدخل رقم التعريف الشخصي", en: "Enter access PIN" },
+      login: { ar: "تسجيل الدخول", en: "Login" },
+      confirm: { ar: "تأكيد", en: "Confirm" },
+      clear: { ar: "مسح", en: "Clear" },
+      open_shift: { ar: "فتح الوردية", en: "Open shift" },
+      cashier: { ar: "الكاشير", en: "Cashier" },
+      opening_float: { ar: "الرصيد الافتتاحي", en: "Opening float" },
+      shift: { ar: "الوردية", en: "Shift" },
+      no_shift: { ar: "لا توجد وردية مفتوحة", en: "No active shift" },
+      tables: { ar: "الطاولات", en: "Tables" },
+      reports: { ar: "التقارير", en: "Reports" },
+      theme: { ar: "الثيم", en: "Theme" },
+      language: { ar: "اللغة", en: "Language" },
+      logout: { ar: "تسجيل الخروج", en: "Logout" },
+      search_placeholder: { ar: "ابحث عن صنف…", en: "Search items…" },
+      empty_menu_title: { ar: "لا توجد أصناف", en: "No items" },
+      empty_menu_hint: { ar: "غيّر التصنيف أو كلمات البحث.", en: "Try adjusting category or search query." },
+      no_active_order: { ar: "لا يوجد طلب نشط", en: "No active order" },
+      current_order: { ar: "الطلب الحالي", en: "Current order" },
+      table: { ar: "الطاولة", en: "Table" },
+      dine_in: { ar: "صالة", en: "Dine-in" },
+      takeaway: { ar: "تيك أواي", en: "Takeaway" },
+      delivery: { ar: "توصيل", en: "Delivery" },
+      empty_order: { ar: "السلة فارغة", en: "Cart is empty" },
+      empty_order_hint: { ar: "أضف أصنافاً من القائمة لبدء الطلب.", en: "Add items from the menu to start an order." },
+      subtotal: { ar: "الإجمالي", en: "Subtotal" },
+      service: { ar: "الخدمة", en: "Service" },
+      vat: { ar: "القيمة المضافة", en: "VAT" },
+      total: { ar: "الإجمالي النهائي", en: "Grand total" },
+      remaining: { ar: "المتبقي", en: "Remaining" },
+      clear_order: { ar: "إلغاء الطلب", en: "Clear order" },
+      park_order: { ar: "تعليق الطلب", en: "Park order" },
+      settle_pay: { ar: "تحصيل الدفع", en: "Settle payment" },
+      remove: { ar: "حذف", en: "Remove" },
+      seats: { ar: "مقاعد", en: "Seats" },
+      table_status_available: { ar: "متاحة", en: "Available" },
+      table_status_occupied: { ar: "مشغولة", en: "Occupied" },
+      table_status_reserved: { ar: "محجوزة", en: "Reserved" },
+      table_status_offline: { ar: "خارج الخدمة", en: "Out of service" },
+      paid_in_full: { ar: "تم السداد بالكامل", en: "Paid in full" },
+      splits: { ar: "دفعات جزئية", en: "Splits" },
+      pay_method_cash: { ar: "نقدي", en: "Cash" },
+      pay_method_card: { ar: "بطاقة", en: "Card" },
+      pay_method_wallet: { ar: "محفظة", en: "Wallet" },
+      cash: { ar: "نقدي", en: "Cash" },
+      card: { ar: "بطاقة", en: "Card" },
+      wallet: { ar: "محفظة", en: "Wallet" },
+      add_split: { ar: "إضافة دفعة", en: "Add split" },
+      complete_payment: { ar: "إتمام الدفع", en: "Complete payment" },
+      shift_summary: { ar: "ملخص الوردية", en: "Shift summary" },
+      start_time: { ar: "وقت البدء", en: "Start time" },
+      orders_count: { ar: "عدد الطلبات", en: "Orders count" },
+      close_shift: { ar: "إغلاق الوردية", en: "Close shift" },
+      reports_placeholder: { ar: "التقارير قريباً", en: "Reports coming soon" },
+      reports_placeholder_hint: { ar: "سيتم إطلاق لوحة التقارير في الإصدارات المقبلة.", en: "A detailed reporting workspace will arrive soon." },
+      payment_completed: { ar: "تم إغلاق الطلب", en: "Order settled" },
+      payment_pending: { ar: "أكمل المبلغ المتبقي", en: "Complete the remaining amount" },
+      tables_attached: { ar: "تم ربط الطاولة", en: "Table linked" },
+      payment_added: { ar: "تمت إضافة الدفعة", en: "Split added" },
+      payment_removed: { ar: "تم حذف الدفعة", en: "Split removed" }
+    }
+  };
+
+  const commands = {
+    "auth.pinKey": ({ truth }, event, el) => {
+      const key = el.getAttribute("data-key");
+      truth.produce((state) => {
+        if (state.ui.stage !== "login") return;
+        const pin = state.ui.login.pin || "";
+        if (key === "⌫") {
+          state.ui.login.pin = pin.slice(0, -1);
+        } else if (/^\d$/.test(key) && pin.length < 4) {
+          state.ui.login.pin = pin + key;
         }
-		
-    });
- app.helpers = {
-        formatCurrency: (amount, locale, currency = 'EGP') => {
-            // ✅ الآن 'app' معرف ومتاح للاستخدام
-            const loc = locale || app.env.get().locale;
-            const val = typeof amount === 'number' ? amount : 0;
-            return new Intl.NumberFormat(loc, { style: 'currency', currency, currencyDisplay: 'symbol' }).format(val);
+      });
+      truth.mark("login-screen");
+    },
+    "auth.pinClear": ({ truth }) => {
+      truth.produce((state) => {
+        if (state.ui.stage !== "login") return;
+        state.ui.login.pin = "";
+        state.ui.login.error = null;
+      });
+      truth.mark("login-screen");
+    },
+    "auth.pinSubmit": ({ truth }) => {
+      truth.produce((state) => {
+        if (state.ui.stage !== "login") return;
+        const pin = state.ui.login.pin || "";
+        const employee = (db.employees || []).find((emp) => emp.pin_code === pin);
+        if (!employee) {
+          state.ui.login.error = "PIN غير صحيح";
+          state.ui.login.pin = "";
+          return;
         }
-    };
+        state.session.cashier = clone(employee);
+        state.ui.login.pin = "";
+        state.ui.login.error = null;
+        state.ui.stage = "shift-setup";
+        state.order = null;
+        state.payments.splits = [];
+        state.payments.buffer = "0";
+      });
+      truth.mark("app-root");
+    },
+    "shift.updateOpeningFloat": ({ truth }, event) => {
+      const value = event && event.target ? event.target.value : "";
+      truth.produce((state) => {
+        state.ui.shift.openingFloat = value;
+      });
+    },
+    "shift.open": ({ truth }) => {
+      truth.produce((state) => {
+        const openingFloat = Number.parseFloat(state.ui.shift.openingFloat || "0") || 0;
+        state.session.shift = {
+          id: new Date().toISOString().slice(11, 19).replace(/[:.]/g, ""),
+          startedAt: new Date().toISOString(),
+          openingFloat: round(openingFloat),
+          orderIds: []
+        };
+        state.ui.stage = "pos";
+        state.ui.overlays.active = null;
+        state.order = createOrder("dine_in");
+        state.payments.splits = [];
+        state.payments.buffer = "0";
+      });
+      truth.rebuildAll();
+    },
+    "shift.close": ({ truth }) => {
+      truth.produce((state) => {
+        if (state.session.shift) {
+          state.completedOrders = state.completedOrders || [];
+          state.session.shift.closedAt = new Date().toISOString();
+        }
+        state.session.shift = null;
+        state.order = null;
+        state.ui.stage = "shift-setup";
+        state.ui.overlays.active = null;
+        state.payments.splits = [];
+        state.payments.buffer = "0";
+      });
+      truth.mark("app-root");
+    },
+    "env.toggleTheme": ({ env, truth }) => {
+      env.toggleTheme();
+      truth.produce((state) => {
+        const envState = env.get();
+        state.env.theme = envState.resolved.theme;
+      });
+      truth.mark("pos-header");
+    },
+    "env.toggleLocale": ({ env, truth }) => {
+      truth.produce((state) => {
+        const next = state.env.locale === "ar" ? "en" : "ar";
+        state.env.locale = next;
+        state.env.dir = next === "ar" ? "rtl" : "ltr";
+        env.setLocale(next);
+      });
+      truth.rebuildAll();
+    },
+    "session.logout": ({ truth }) => {
+      truth.produce((state) => {
+        state.ui.stage = "login";
+        state.session.cashier = null;
+        state.session.shift = null;
+        state.order = null;
+        state.payments.splits = [];
+        state.payments.buffer = "0";
+        state.ui.login.pin = "";
+        state.ui.login.error = null;
+      });
+      truth.rebuildAll();
+    },
+    "view.showTables": ({ truth }) => {
+      truth.produce((state) => {
+        if (state.ui.stage !== "pos") return;
+        ensureOrder(state);
+        state.ui.overlays.active = "tables";
+      });
+      truth.mark("modals-root");
+    },
+    "view.showReports": ({ truth }) => {
+      truth.produce((state) => {
+        if (state.ui.stage !== "pos") return;
+        state.ui.overlays.active = "reports";
+      });
+      truth.mark("modals-root");
+    },
+    "view.closeOverlay": ({ truth }) => {
+      truth.produce((state) => {
+        state.ui.overlays.active = null;
+        state.ui.overlays.payload = null;
+      });
+      truth.mark("modals-root");
+    },
+    "menu.search": ({ truth }, event) => {
+      const value = event && event.target ? event.target.value : "";
+      truth.produce((state) => {
+        state.ui.menu.search = value;
+      });
+      truth.mark("menu-panel");
+    },
+    "menu.selectCategory": ({ truth }, event, el) => {
+      const categoryId = el.getAttribute("data-category-id") || "all";
+      truth.produce((state) => {
+        state.ui.menu.category = categoryId;
+      });
+      truth.mark("menu-panel");
+    },
+    "order.addItem": ({ truth }, event, el) => {
+      const target = el || (event && event.target && event.target.closest && event.target.closest("[data-item-id]"));
+      if (!target) return;
+      const itemId = target.getAttribute("data-item-id");
+      truth.produce((state) => {
+        if (state.ui.stage !== "pos") return;
+        const order = ensureOrder(state);
+        const item = (state.catalog.items || []).find((it) => String(it.id) === String(itemId));
+        if (!item) return;
+        const locale = state.env.locale || "ar";
+        const existing = order.lines.find((line) => !line.modifiers?.length && String(line.itemId) === String(item.id));
+        if (existing) {
+          existing.qty += 1;
+          existing.total = round(existing.price * existing.qty);
+        } else {
+          const translation = translateItem(item, locale);
+          order.lines.push({
+            id: nextId("line"),
+            itemId: item.id,
+            name: translation.name,
+            qty: 1,
+            price: item.price,
+            total: round(item.price),
+            modifiers: [],
+            notes: ""
+          });
+        }
+        order.totals = computeTotals(order.lines, state.settings);
+      });
+      truth.mark(["order-panel", "footer-bar"]);
+    },
+    "order.incrementLine": ({ truth }, event, el) => {
+      const lineId = el.getAttribute("data-line-id");
+      truth.produce((state) => {
+        if (!lineId || !state.order) return;
+        const line = state.order.lines.find((ln) => ln.id === lineId);
+        if (!line) return;
+        line.qty += 1;
+        line.total = round(line.price * line.qty);
+        state.order.totals = computeTotals(state.order.lines, state.settings);
+      });
+      truth.mark(["order-panel", "footer-bar"]);
+    },
+    "order.decrementLine": ({ truth }, event, el) => {
+      const lineId = el.getAttribute("data-line-id");
+      truth.produce((state) => {
+        if (!lineId || !state.order) return;
+        const lines = state.order.lines;
+        const index = lines.findIndex((ln) => ln.id === lineId);
+        if (index < 0) return;
+        const line = lines[index];
+        line.qty = Math.max(0, line.qty - 1);
+        if (line.qty === 0) {
+          lines.splice(index, 1);
+        } else {
+          line.total = round(line.price * line.qty);
+        }
+        state.order.totals = computeTotals(lines, state.settings);
+      });
+      truth.mark(["order-panel", "footer-bar"]);
+    },
+    "order.removeLine": ({ truth }, event, el) => {
+      const lineId = el.getAttribute("data-line-id");
+      truth.produce((state) => {
+        if (!lineId || !state.order) return;
+        const lines = state.order.lines || [];
+        const index = lines.findIndex((ln) => ln.id === lineId);
+        if (index >= 0) {
+          lines.splice(index, 1);
+          state.order.totals = computeTotals(lines, state.settings);
+        }
+      });
+      truth.mark(["order-panel", "footer-bar"]);
+    },
+    "order.setType": ({ truth }, event, el) => {
+      const type = el.getAttribute("data-type") || "dine_in";
+      truth.produce((state) => {
+        if (!state.order) return;
+        state.order.type = type;
+        if (type !== "dine_in") {
+          state.order.tableIds = [];
+        }
+      });
+      truth.mark("order-panel");
+    },
+    "order.clear": ({ truth }) => {
+      truth.produce((state) => {
+        if (!state.order) return;
+        const type = state.order.type;
+        state.order = createOrder(type);
+        state.payments.splits = [];
+        state.payments.buffer = "0";
+      });
+      truth.mark(["order-panel", "footer-bar", "modals-root"]);
+    },
+    "order.park": ({ truth }) => {
+      truth.produce((state) => {
+        if (!state.order || !state.order.lines.length) return;
+        const snapshot = clone(state.order);
+        state.parkedOrders = state.parkedOrders || [];
+        state.parkedOrders.push(snapshot);
+        const type = state.order.type;
+        state.order = createOrder(type);
+        state.payments.splits = [];
+        state.payments.buffer = "0";
+      });
+      truth.mark(["order-panel", "footer-bar"]);
+    },
+    "tables.attach": ({ truth }, event, el) => {
+      const tableId = el.getAttribute("data-table-id");
+      truth.produce((state) => {
+        if (!tableId) return;
+        const order = ensureOrder(state);
+        if (!order.tableIds) order.tableIds = [];
+        if (order.tableIds.includes(tableId)) {
+          order.tableIds = order.tableIds.filter((id) => id !== tableId);
+        } else {
+          order.tableIds.push(tableId);
+        }
+        state.ui.overlays.active = null;
+      });
+      truth.mark(["order-panel", "modals-root"]);
+      notify(truth, "tables_attached", "success");
+    },
+    "payments.open": ({ truth }) => {
+      truth.produce((state) => {
+        if (!state.order || !state.order.lines.length) return;
+        state.ui.overlays.active = "payments";
+        state.payments.buffer = getDue(state).toFixed(2);
+      });
+      truth.mark("modals-root");
+    },
+    "payments.close": ({ truth }) => {
+      truth.produce((state) => {
+        state.ui.overlays.active = null;
+      });
+      truth.mark("modals-root");
+    },
+    "payments.key": ({ truth }, event, el) => {
+      const key = el.getAttribute("data-key");
+      truth.produce((state) => {
+        let buffer = state.payments.buffer || "0";
+        if (key === "⌫") {
+          buffer = buffer.length > 1 ? buffer.slice(0, -1) : "0";
+        } else if (key === ".") {
+          if (!buffer.includes(".")) buffer += ".";
+        } else if (/^\d$/.test(key)) {
+          buffer = buffer === "0" ? key : buffer + key;
+        }
+        state.payments.buffer = buffer;
+      });
+      truth.mark("modals-root");
+    },
+    "payments.clearBuffer": ({ truth }) => {
+      truth.produce((state) => {
+        state.payments.buffer = "0";
+      });
+      truth.mark("modals-root");
+    },
+    "payments.addSplit": ({ truth }) => {
+      truth.produce((state) => {
+        if (!state.order) return;
+        const buffer = state.payments.buffer || "0";
+        const amount = round(Number.parseFloat(buffer.replace(/,/g, ".")) || 0);
+        const due = getDue(state);
+        if (due <= 0) {
+          state.payments.buffer = "0.00";
+          return;
+        }
+        if (amount <= 0) {
+          state.payments.buffer = due.toFixed(2);
+          return;
+        }
+        const applied = Math.min(due, amount);
+        state.payments.splits = state.payments.splits || [];
+        state.payments.splits.push({
+          id: nextId("split"),
+          method: state.payments.method || "cash",
+          amount: applied
+        });
+        state.payments.buffer = getDue(state).toFixed(2);
+      });
+      truth.mark(["footer-bar", "modals-root"]);
+      notify(truth, "payment_added", "success");
+    },
+    "payments.removeSplit": ({ truth }, event, el) => {
+      const splitId = el.getAttribute("data-split-id");
+      truth.produce((state) => {
+        if (!splitId) return;
+        state.payments.splits = (state.payments.splits || []).filter((split) => split.id !== splitId);
+        state.payments.buffer = getDue(state).toFixed(2);
+      });
+      truth.mark(["footer-bar", "modals-root"]);
+      notify(truth, "payment_removed", "primary");
+    },
+    "payments.setMethod": ({ truth }, event, el) => {
+      const method = el.getAttribute("data-method") || "cash";
+      truth.produce((state) => {
+        state.payments.method = method;
+      });
+      truth.mark("modals-root");
+    },
+    "payments.complete": ({ truth }) => {
+      let insufficient = false;
+      let completed = false;
+      truth.produce((state) => {
+        if (!state.order) return;
+        const due = getDue(state);
+        if (due > 0.009) {
+          state.payments.buffer = due.toFixed(2);
+          state.ui.overlays.active = "payments";
+          state.ui.overlays.payload = { error: "due" };
+          insufficient = true;
+          return;
+        }
+        const snapshot = clone(state.order);
+        snapshot.payments = clone(state.payments.splits || []);
+        snapshot.status = "settled";
+        snapshot.closedAt = new Date().toISOString();
+        state.completedOrders = state.completedOrders || [];
+        state.completedOrders.push(snapshot);
+        if (state.session.shift) {
+          state.session.shift.orderIds = state.session.shift.orderIds || [];
+          state.session.shift.orderIds.push(snapshot.id);
+        }
+        state.order = createOrder();
+        state.payments.splits = [];
+        state.payments.buffer = "0";
+        state.ui.overlays.active = null;
+        completed = true;
+      });
+      truth.mark(["order-panel", "footer-bar", "modals-root"]);
+      if (insufficient) {
+        notify(truth, "payment_pending", "danger");
+      } else if (completed) {
+        notify(truth, "payment_completed", "success");
+      }
+    },
+    "ui.dismissToast": ({ truth }, event, el) => {
+      const toastId = el.getAttribute("data-toast-id");
+      truth.produce((state) => {
+        if (!toastId) return;
+        state.ui.toasts = (state.ui.toasts || []).filter((toast) => toast.id !== toastId);
+      });
+      truth.mark("toasts-root");
+    }
+  };
 
-    // --- الخطوة 3: اجعل التطبيق متاحًا بشكل عام ---
-    window.app = app;
+  const app = Core.createApp({
+    mount: "#app",
+    rootComponent: "POSRoot",
+    initial: initialState,
+    commands,
+    locale: initialState.env.locale,
+    dir: initialState.env.dir,
+    theme: initialState.env.theme,
+    dictionaries,
+    persistEnv: true,
+    helpers: {}
+  });
 
+  app.helpers = {
+    formatCurrency(value) {
+      const amount = Number(value) || 0;
+      const state = app.truth.get();
+      const symbol = (state.settings.currency && state.settings.currency[state.env.locale]) || state.settings.currency?.en || "EGP";
+      return `${symbol} ${amount.toFixed(2)}`.trim();
+    }
+  };
 
-
-    window.app = app;
-    app.truth.mark('pos-root');
 })(window);
-


### PR DESCRIPTION
## Summary
- replace the bare POS host HTML with a full-screen container and shared utility styles for Tailwind and Mishkah assets
- rebuild the POS component tree with staged login/shift screens, the main layout (header, menu grid, order panel, footer), modal surfaces, and toasts
- overhaul POS truth state, dictionaries, and commands to support the refreshed workflow from authentication through settlement

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68d6d2f9e828833391084494be6bd850