### PR TITLE
Ensure POS components bootstrap after Mishkah initialization

### DIFF
--- a/mishkah-comp-v5.js
+++ b/mishkah-comp-v5.js
@@ -4097,5 +4097,17 @@ Comp.define("ReportTool", (A, s, app, p = {}, sl = {}) => {
   Comp.util.register('Hotkeys', Hotkeys);
   
   M.Comp = Comp;
+  if (window && window.dispatchEvent) {
+    try {
+      window.dispatchEvent(new CustomEvent("mishkah:comp-ready", { detail: { version: "v5" } }));
+    } catch (error) {
+      const doc = typeof document !== "undefined" ? document : null;
+      const event = doc && doc.createEvent ? doc.createEvent("Event") : null;
+      if (event && event.initEvent) {
+        event.initEvent("mishkah:comp-ready", false, false);
+        window.dispatchEvent(event);
+      }
+    }
+  }
 
 })(window);

--- a/mishkah-core-v5.js
+++ b/mishkah-core-v5.js
@@ -737,6 +737,17 @@
     createMessenger,
     utils: { now, asArray, createRing, basicSanitize },
   };
+  if (typeof window !== "undefined" && window.dispatchEvent) {
+    try {
+      window.dispatchEvent(new CustomEvent("mishkah:core-ready", { detail: { version: "v5" } }));
+    } catch (error) {
+      const event = window.document && window.document.createEvent ? window.document.createEvent("Event") : null;
+      if (event && event.initEvent) {
+        event.initEvent("mishkah:core-ready", false, false);
+        window.dispatchEvent(event);
+      }
+    }
+  }
 })(window);
 
 // ————————————————————————————————————————————————————————————————


### PR DESCRIPTION
## Summary
- defer POS component registration until Mishkah Atoms/Comp are available and mark completion to avoid duplicate work
- emit `mishkah:comp-ready` and `mishkah:core-ready` events from Mishkah modules so POS can react once the framework boots

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d7aac0596483339d2e463b0662da72