### PR TITLE
Fix menu card command wiring in POS

### DIFF
--- a/pos-comp.js
+++ b/pos-comp.js
@@ -497,34 +497,12 @@
     const helpers = app.helpers || {};
     const formatCurrency = helpers.formatCurrency || ((v) => v.toFixed(2));
 
-    const triggerAddItem = (event, originEl) => {
-      if (!event) return;
-      let targetEl = originEl;
-      if (targetEl && targetEl.closest) targetEl = targetEl.closest("[data-item-id]");
-      if (!targetEl && event.target && event.target.closest) {
-        targetEl = event.target.closest("[data-item-id]");
-      }
-      app.dispatch("order.addItem", event, targetEl || originEl || event.target);
-    };
-
-    const handleCardClick = (event) => {
-      triggerAddItem(event, event.currentTarget || event.target);
-    };
-
-    const handleCardKeyDown = (event) => {
-      const key = event.key;
-      const isActivationKey = key === "Enter" || key === " " || key === "Spacebar" || key === "Space";
-      if (!isActivationKey) return;
-      event.preventDefault();
-      triggerAddItem(event, event.currentTarget || event.target);
-    };
-
     return A.Div({
       "data-item-id": item.id,
       role: "button",
       tabIndex: 0,
-      onClick: handleCardClick,
-      onKeyDown: handleCardKeyDown,
+      "data-onclick": "order.addItem",
+      "data-onkeydown": "order.addItem",
       style: {
         cursor: "pointer",
         borderRadius: "20px",

--- a/pos.js
+++ b/pos.js
@@ -693,6 +693,14 @@
       truth.mark("menu-panel");
     },
     "order.addItem": ({ truth }, event, el) => {
+      if (event && event.type === "keydown") {
+        const key = event.key;
+        const activationKeys = ["Enter", " ", "Space", "Spacebar"];
+        if (!activationKeys.includes(key)) {
+          return;
+        }
+        if (event.preventDefault) event.preventDefault();
+      }
       const target = el || (event && event.target && event.target.closest && event.target.closest("[data-item-id]"));
       if (!target) return;
       const itemId = target.getAttribute("data-item-id");


### PR DESCRIPTION
## Summary
- ensure POS menu cards use Mishkah's delegated command attributes
- guard `order.addItem` to handle keyboard activation keys before enqueuing marks

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d827f1b77c8333b00e34068b4c7881