### PR TITLE
Add POS UI scaffold and supporting components

### DIFF
--- a/pos.html
+++ b/pos.html
@@ -1,0 +1,408 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8"/>
+  <title>مشكاة — نقطة البيع للمطاعم</title>
+  <script src="./mishkah-utils.js"></script>
+  <script src="./mishkah.core.js"></script>
+  <script src="./mishkah-ui.js"></script>
+  <script src="./pos-mock-data.js"></script>
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+  (function(){
+    const M = Mishkah;
+    const UI = M.UI;
+    const U = M.utils;
+    const D = M.DSL;
+    const { tw, token } = U.twcss;
+
+    const MOCK = (window.database)||{};
+    const mockCategories = MOCK.categories || [];
+    const mockItems = (MOCK.items || []).slice(0, 9);
+    const mockTables = MOCK.tables || [];
+    const currency = (MOCK.settings && MOCK.settings.currency && MOCK.settings.currency.ar) || 'ج.م';
+
+    const i18nDict = {
+      ui:{
+        shift:'الوردية',
+        cashier:'الكاشير',
+        dine_in:'صالة',
+        takeaway:'تيك اواي',
+        delivery:'توصيل',
+        search:'ابحث في المنيو',
+        categories:'التصنيفات',
+        subtotal:'الإجمالي الفرعي',
+        service:'خدمة',
+        vat:'ضريبة',
+        discount:'خصم',
+        total:'الإجمالي المستحق',
+        cart_empty:'لم يتم إضافة أصناف بعد',
+        tables:'الطاولات',
+        payments:'المدفوعات',
+        reports:'التقارير',
+        indexeddb:'قاعدة البيانات المحلية',
+        kds:'نظام المطبخ (KDS)',
+        last_sync:'آخر مزامنة',
+        connect:'اتصال',
+        sync_now:'مزامنة الآن',
+        save_order:'حفظ الطلب',
+        settle_and_print:'تحصيل و طباعة',
+        print:'طباعة فقط',
+        split:'تقسيم الدفعات',
+        quick_actions:'إجراءات سريعة',
+        guests:'عدد الأفراد',
+        bill_summary:'ملخص الفاتورة',
+        status:'الحالة',
+        totals:'الإجماليات',
+        favorites:'مفضلة',
+        modifiers:'التخصيصات',
+        notes:'ملاحظات',
+        seat_map:'خريطة الطاولات',
+        overview:'نظرة عامة',
+        top_selling:'الأكثر مبيعًا',
+        avg_ticket:'متوسط الفاتورة',
+        orders_count:'عدد الطلبات',
+        open_reports:'فتح التقارير'
+      }
+    };
+
+    const posState = {
+      head:{ title:'مشكاة — نقطة بيع' },
+      env:{ theme:'dark', lang:'ar', dir:'rtl' },
+      i18n:{ lang:'ar', fallback:'en', dict:i18nDict },
+      data:{
+        user:{
+          name: MOCK.employees ? MOCK.employees[0]?.full_name || 'أحمد محمود' : 'أحمد محمود',
+          role: 'كاشير',
+          shift:'الصباحية',
+          shiftNo:'#103'
+        },
+        status:{
+          indexeddb:{ state:'offline', lastSync:'لم تتم المزامنة بعد' },
+          kds:{ state:'idle', endpoint:'wss://signal.mas.com.eg/signaldata?id=96nnVOIawRs7Wo_XpAFM0Q' }
+        },
+        menu:{
+          search:'',
+          category:'all',
+          categories: mockCategories.map(cat=>({ id:cat.id, label: cat.translations?.ar || cat.translations?.en || cat.id })),
+          items: mockItems.map(item=>({
+            id:item.id,
+            name:item.translations?.ar?.name || item.translations?.en?.name || 'صنف',
+            description:item.translations?.ar?.description || '',
+            price:item.price,
+            image:item.image
+          }))
+        },
+        order:{
+          id:'draft-001',
+          type:'dine_in',
+          table:{ id: mockTables.find(t=>t.status==='occupied')?.id || 'T1', name: mockTables.find(t=>t.status==='occupied')?.name || 'طاولة 1' },
+          guests:3,
+          lines:[
+            { id:'line-1', name:'حواوشي درويش', qty:2, price:120, total:240, notes:'بدون بصل', modifiers:['جبنة زيادة'] },
+            { id:'line-2', name:'سندويتش كبدة', qty:1, price:55, total:55, notes:'إضافة فلفل', modifiers:['طحينة إضافية'] },
+            { id:'line-3', name:'أرز بالشعرية', qty:2, price:68, total:136, notes:'', modifiers:[] }
+          ],
+          totals:{ subtotal:431, service:51.72, vat:60.34, discount:0, due:543.06 }
+        },
+        tables: mockTables,
+        payments:{
+          methods:[
+            { id:'cash', label:'نقدي', icon:'💵' },
+            { id:'card', label:'بطاقة', icon:'💳' },
+            { id:'wallet', label:'محفظة', icon:'📱' },
+            { id:'voucher', label:'قسيمة', icon:'🎟️' }
+          ],
+          split:[
+            { id:'sp1', method:'cash', amount:250 },
+            { id:'sp2', method:'card', amount:293.06 }
+          ]
+        },
+        reports:{
+          salesToday:'12,430 ' + currency,
+          ordersCount:'58 طلب',
+          avgTicket:'214 ' + currency,
+          topItem:'حواوشي درويش',
+          range:'today'
+        }
+      },
+      ui:{
+        modals:{ tables:false, payments:false, reports:false },
+        drawers:{ kds:false },
+        activePanels:{ report:'sales' }
+      }
+    };
+
+    const app = M.app.createApp(posState, {});
+    const auto = U.twcss.auto(posState, app, { pageScaffold:true });
+
+    function statusBadge(state, label){
+      const tone = state==='online'? 'status/online': state==='offline'? 'status/offline': 'status/idle';
+      return UI.Badge({
+        variant:'badge/status',
+        attrs:{ class: tw`${token(tone)}` },
+        leading: state==='online'? '●': state==='offline'? '✖' : '…',
+        text: `${label} • ${state}`
+      });
+    }
+
+    function Header(db){
+      const user = db.data.user;
+      return UI.Toolbar({
+        left:[
+          D.Text.Span({ attrs:{ class: tw`text-2xl font-black tracking-tight` }}, ['Mishkah POS']),
+          UI.Badge({ text: db.data.order.type==='dine_in'? i18nDict.ui.dine_in: i18nDict.ui.takeaway, leading:'🍽️', variant:'badge/ghost', attrs:{ class: tw`text-sm` } })
+        ],
+        right:[
+          UI.Badge({ text:`${i18nDict.ui.shift}: ${user.shift}`, leading:'🕑', variant:'badge/ghost' }),
+          UI.Badge({ text:`${i18nDict.ui.cashier}: ${user.name}`, leading:'👤', variant:'badge/ghost' }),
+          UI.Button({ attrs:{ gkey:'pos:session:logout' }, variant:'ghost', size:'sm' }, ['🚪 خروج'])
+        ]
+      });
+    }
+
+    function MenuColumn(db){
+      const menu = db.data.menu;
+      const chips = [{ id:'all', label:'الكل' }].concat(menu.categories);
+      const chipItems = chips.map(cat=>({
+        id:cat.id,
+        label:cat.label,
+        attrs:{ gkey:'pos:menu:category', 'data-category-id':cat.id }
+      }));
+      return D.Containers.Section({ attrs:{ class: tw`flex flex-col gap-4` }}, [
+        UI.Card({
+          variant:'card/soft-1',
+          content: D.Containers.Div({ attrs:{ class: tw`space-y-4` }}, [
+            UI.SearchBar({ value:menu.search, placeholder:i18nDict.ui.search, onInput:'pos:menu:search', trailing:[
+              UI.Button({ attrs:{ gkey:'pos:menu:favorite', class: tw`rounded-full` }, variant:'ghost', size:'sm' }, ['⭐ المفضلة'])
+            ] }),
+            UI.ChipGroup({ items: chipItems, activeId: menu.category })
+          ])
+        }),
+        D.Containers.Section({ attrs:{ class: tw`${token('scroll-panel')}` }}, [
+          D.Containers.Div({ attrs:{ class: tw`${token('scroll-panel/head')}` }}, [
+            D.Text.Strong({}, [i18nDict.ui.categories]),
+            UI.Button({ attrs:{ gkey:'pos:menu:load-more' }, variant:'ghost', size:'sm' }, ['عرض المزيد'])
+          ]),
+          UI.ScrollArea({
+            attrs:{ class: tw`${token('scroll-panel/body')} p-4` },
+            children:[
+              D.Containers.Div({ attrs:{ class: tw`grid gap-3 sm:grid-cols-2 xl:grid-cols-3` }},
+                menu.items.map(item=> UI.Card({
+                  variant:'card/soft-2',
+                  content: D.Containers.Div({ attrs:{ class: tw`space-y-3` }}, [
+                    D.Containers.Div({ attrs:{ class: tw`aspect-square overflow-hidden rounded-[var(--radius)] bg-[var(--surface-2)]` }}, [
+                      item.image ? D.Containers.Img({ attrs:{ src:item.image, alt:item.name, class: tw`w-full h-full object-cover` }}) :
+                        D.Containers.Div({ attrs:{ class: tw`w-full h-full grid place-items-center text-3xl` }}, ['🍽️'])
+                    ]),
+                    D.Containers.Div({ attrs:{ class: tw`space-y-1` }}, [
+                      D.Text.Strong({ attrs:{ class: tw`text-base` }}, [item.name]),
+                      item.description ? D.Text.P({ attrs:{ class: tw`text-sm ${token('muted')}` }}, [item.description]) : null,
+                      UI.PriceText({ amount:item.price, currency:'EGP', locale:'ar-EG' })
+                    ].filter(Boolean)),
+                    UI.Button({ attrs:{ gkey:'pos:menu:add', 'data-item-id':item.id, class: tw`w-full` }, variant:'solid', size:'sm' }, ['إضافة إلى الطلب'])
+                  ])
+                }))
+              )
+            ]
+          }),
+          D.Containers.Div({ attrs:{ class: tw`${token('scroll-panel/footer')} flex items-center justify-between` }}, [
+            statusBadge(db.data.status.indexeddb.state, i18nDict.ui.indexeddb),
+            UI.Button({ attrs:{ gkey:'pos:indexeddb:sync' }, variant:'ghost', size:'sm' }, [i18nDict.ui.sync_now])
+          ])
+        ])
+      ]);
+    }
+
+    function OrderLine(line){
+      return UI.ListItem({
+        leading: D.Text.Span({ attrs:{ class: tw`text-lg` }}, ['🍲']),
+        content:[
+          D.Text.Strong({}, [line.name]),
+          line.modifiers && line.modifiers.length ? D.Text.Span({ attrs:{ class: tw`text-xs ${token('muted')}` }}, [line.modifiers.join(' • ')]) : null,
+          line.notes ? D.Text.Span({ attrs:{ class: tw`text-xs ${token('muted')}` }}, ['📝 ', line.notes]) : null
+        ].filter(Boolean),
+        trailing:[
+          UI.QtyStepper({ value:line.qty, gkeyDec:'pos:order:line:dec', gkeyInc:'pos:order:line:inc', gkeyEdit:'pos:order:line:qty', dataId:line.id }),
+          UI.PriceText({ amount:line.total, currency:'EGP', locale:'ar-EG' }),
+          UI.Button({ attrs:{ gkey:'pos:order:line:actions' }, variant:'ghost', size:'sm' }, ['⋯'])
+        ]
+      });
+    }
+
+    function TotalsSection(totals){
+      const rows = [
+        { label:i18nDict.ui.subtotal, value:totals.subtotal },
+        { label:i18nDict.ui.service, value:totals.service },
+        { label:i18nDict.ui.vat, value:totals.vat },
+        { label:i18nDict.ui.discount, value:totals.discount }
+      ];
+      return D.Containers.Div({ attrs:{ class: tw`space-y-2` }}, [
+        ...rows.map(row=> UI.HStack({ attrs:{ class: tw`${token('split')} text-sm` }}, [
+          D.Text.Span({ attrs:{ class: tw`${token('muted')}` }}, [row.label]),
+          UI.PriceText({ amount:row.value, currency:'EGP', locale:'ar-EG' })
+        ])),
+        UI.Divider(),
+        UI.HStack({ attrs:{ class: tw`${token('split')} text-lg font-semibold` }}, [
+          D.Text.Span({}, [i18nDict.ui.total]),
+          UI.PriceText({ amount:totals.due, currency:'EGP', locale:'ar-EG' })
+        ])
+      ]);
+    }
+
+    function PaymentSummary(db){
+      const split = db.data.payments.split;
+      const methods = db.data.payments.methods || [];
+      return UI.Card({
+        variant:'card/soft-1',
+        title:'تقسيم المدفوعات',
+        content: D.Containers.Div({ attrs:{ class: tw`space-y-2` }}, [
+          ...split.map(entry=> UI.HStack({ attrs:{ class: tw`${token('split')} text-sm` }}, [
+            D.Text.Span({}, [
+              `${methods.find(m=>m.id===entry.method)?.icon || '💳'} ${methods.find(m=>m.id===entry.method)?.label || entry.method}`
+            ]),
+            UI.PriceText({ amount:entry.amount, currency:'EGP', locale:'ar-EG' })
+          ])),
+          UI.Button({ attrs:{ gkey:'pos:payments:split', class: tw`w-full` }, variant:'ghost', size:'sm' }, [i18nDict.ui.split])
+        ])
+      });
+    }
+
+    function OrderColumn(db){
+      const order = db.data.order;
+      return D.Containers.Section({ attrs:{ class: tw`flex flex-col gap-4` }}, [
+        D.Containers.Section({ attrs:{ class: tw`${token('scroll-panel')}` }}, [
+          D.Containers.Div({ attrs:{ class: tw`${token('scroll-panel/head')}` }}, [
+            D.Containers.Div({ attrs:{ class: tw`flex flex-col` }}, [
+              D.Text.Strong({}, [`طلب ${order.id}`]),
+              D.Text.Span({ attrs:{ class: tw`text-xs ${token('muted')}` }}, [`${i18nDict.ui.tables}: ${order.table.name} • ${i18nDict.ui.guests}: ${order.guests}`])
+            ]),
+            UI.Button({ attrs:{ gkey:'pos:tables:open' }, variant:'ghost', size:'sm' }, [i18nDict.ui.tables])
+          ]),
+          UI.ScrollArea({
+            attrs:{ class: tw`${token('scroll-panel/body')} p-4 space-y-2` },
+            children:[ order.lines && order.lines.length ? UI.List({ children: order.lines.map(OrderLine) }) : UI.EmptyState({ icon:'🧺', title:i18nDict.ui.cart_empty, description:'اختر صنفًا من القائمة لإضافته إلى الطلب.' }) ]
+          }),
+          D.Containers.Div({ attrs:{ class: tw`${token('scroll-panel/footer')} space-y-4` }}, [
+            TotalsSection(order.totals),
+            UI.HStack({ attrs:{ class: tw`gap-2` }}, [
+              UI.Button({ attrs:{ gkey:'pos:order:discount', class: tw`flex-1` }, variant:'ghost', size:'sm' }, ['خصم']),
+              UI.Button({ attrs:{ gkey:'pos:order:note', class: tw`flex-1` }, variant:'ghost', size:'sm' }, [i18nDict.ui.notes]),
+              UI.Button({ attrs:{ gkey:'pos:order:clear' }, variant:'ghost', size:'sm' }, ['مسح'])
+            ])
+          ])
+        ]),
+        PaymentSummary(db),
+        UI.StatCard({
+          title:i18nDict.ui.reports,
+          value:db.data.reports.salesToday,
+          meta:`${i18nDict.ui.orders_count}: ${db.data.reports.ordersCount}`,
+          footer:[
+            UI.Button({ attrs:{ gkey:'pos:reports:toggle', class: tw`w-full` }, variant:'ghost', size:'sm' }, [i18nDict.ui.open_reports])
+          ]
+        })
+      ]);
+    }
+
+    function FooterBar(db){
+      return UI.Footerbar({
+        left:[
+          statusBadge(db.data.status.kds.state, i18nDict.ui.kds),
+          UI.Button({ attrs:{ gkey:'pos:kds:connect' }, variant:'ghost', size:'sm' }, ['إعادة الاتصال'])
+        ],
+        right:[
+          UI.Button({ attrs:{ gkey:'pos:order:save', class: tw`min-w-[120px]` }, variant:'soft', size:'md' }, [i18nDict.ui.save_order]),
+          UI.Button({ attrs:{ gkey:'pos:payments:open', class: tw`min-w-[160px]` }, variant:'solid', size:'md' }, [i18nDict.ui.settle_and_print]),
+          UI.Button({ attrs:{ gkey:'pos:order:print', class: tw`min-w-[120px]` }, variant:'ghost', size:'md' }, [i18nDict.ui.print])
+        ]
+      });
+    }
+
+    function TablesModal(db){
+      if(!db.ui.modals.tables) return null;
+      const tables = db.data.tables || [];
+      return UI.Modal({
+        open:true,
+        title:i18nDict.ui.tables,
+        description:'اختر طاولة لإسناد الطلب أو دمج الطاولات.',
+        actions:[
+          UI.ScrollArea({
+            attrs:{ class: tw`max-h-[60vh] w-full space-y-2 p-4` },
+            children: tables.map(table=> UI.ListItem({
+              leading: D.Text.Span({ attrs:{ class: tw`text-lg` }}, ['🪑']),
+              content:[
+                D.Text.Strong({}, [table.name]),
+                D.Text.Span({ attrs:{ class: tw`text-xs ${token('muted')}` }}, [`${i18nDict.ui.guests}: ${table.seats}`])
+              ],
+              trailing:[ statusBadge(table.status==='available'?'online': table.status==='occupied'?'idle':'offline', table.status) ],
+              attrs:{ gkey:'pos:tables:select', 'data-table-id':table.id }
+            }))
+          }),
+          UI.Button({ attrs:{ gkey:'pos:tables:merge' }, variant:'ghost', size:'sm' }, ['دمج الطاولات'])
+        ]
+      });
+    }
+
+    function PaymentsSheet(db){
+      if(!db.ui.modals.payments) return null;
+      return UI.Drawer({
+        open:true,
+        side:'end',
+        header:D.Containers.Div({ attrs:{ class: tw`space-y-1` }}, [
+          D.Text.Strong({}, [i18nDict.ui.payments]),
+          D.Text.Span({ attrs:{ class: tw`text-xs ${token('muted')}` }}, ['قم باختيار وسيلة الدفع وإدخال القيمة.'])
+        ]),
+        content:D.Containers.Div({ attrs:{ class: tw`space-y-3` }}, [
+          UI.ChipGroup({
+            items: db.data.payments.methods.map(method=> ({ id:method.id, label:`${method.icon} ${method.label}`, attrs:{ gkey:'pos:payments:method', 'data-method-id':method.id } })),
+            activeId: db.data.payments.methods[0]?.id
+          }),
+          UI.Button({ attrs:{ gkey:'pos:payments:capture', class: tw`w-full` }, variant:'solid', size:'md' }, ['تأكيد الدفع'])
+        ])
+      });
+    }
+
+    function ReportsDrawer(db){
+      if(!db.ui.modals.reports) return null;
+      return UI.Drawer({
+        open:true,
+        side:'start',
+        header:D.Containers.Div({ attrs:{ class: tw`space-y-1` }}, [
+          D.Text.Strong({}, [i18nDict.ui.reports]),
+          D.Text.Span({ attrs:{ class: tw`text-xs ${token('muted')}` }}, ['مؤشرات مباشرة من IndexedDB.'])
+        ]),
+        content:D.Containers.Div({ attrs:{ class: tw`space-y-3` }}, [
+          UI.StatCard({ title:'إجمالي المبيعات', value:db.data.reports.salesToday }),
+          UI.StatCard({ title:'أفضل صنف', value:db.data.reports.topItem }),
+          UI.StatCard({ title:i18nDict.ui.avg_ticket, value:db.data.reports.avgTicket })
+        ])
+      });
+    }
+
+    Mishkah.app.setBody(function(db){
+      return UI.AppRoot({
+        shell: D.Containers.Div({ attrs:{ class: tw`min-h-screen flex flex-col` }}, [
+          Header(db),
+          D.Containers.Main({ attrs:{ class: tw`flex-1 grid gap-4 lg:grid-cols-[minmax(0,2.2fr)_minmax(0,1fr)] p-4 pb-24` }}, [
+            MenuColumn(db),
+            OrderColumn(db)
+          ]),
+          FooterBar(db)
+        ]),
+        overlays:[
+          TablesModal(db),
+          PaymentsSheet(db),
+          ReportsDrawer(db),
+          db.ui?.toasts ? UI.ToastHost({ toasts: db.ui.toasts }) : null
+        ].filter(Boolean)
+      });
+    });
+
+    app.setOrders(Object.assign({}, UI.orders, auto.orders));
+    app.mount('#app');
+  })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extend Mishkah UI tokens with badges, lists, scroll panels, and status helpers
- add reusable atoms such as Badge, ChipGroup, SearchBar, QtyStepper, PriceText, and StatCard
- publish a complete pos.html shell that wires menu, cart, payments, tables, and reports placeholders with stub orders

## Testing
- No automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68de467e11c08333959d45a1c5f9ccf8