### PR TITLE
Revamp POS shell with live state, localization, and controls

### DIFF
--- a/pos.html
+++ b/pos.html
@@ -1,0 +1,1443 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"/>
+  <title>مشكاة — نقطة البيع للمطاعم</title>
+  <style>
+    :root { color-scheme: light dark; }
+    html, body { height: 100%; margin: 0; overflow: hidden; background: var(--background, #0f1115); }
+    body { font-family: "Tajawal", "Cairo", system-ui, sans-serif; touch-action: manipulation; }
+    #app { height: 100%; }
+    .pos-shell { height: 100%; }
+  </style>
+  <script src="./mishkah-utils.js"></script>
+  <script src="./mishkah.core.js"></script>
+  <script src="./mishkah-ui.js"></script>
+  <script src="./pos-mock-data.js"></script>
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+  (function(){
+    const M = Mishkah;
+    const UI = M.UI;
+    const U = M.utils;
+    const D = M.DSL;
+    const { tw, token } = U.twcss;
+
+    const MOCK = window.database || {};
+    const settings = MOCK.settings || {};
+    const currencyMap = settings.currency || { ar:'ج.م', en:'EGP' };
+
+    const ORDER_TYPES = [
+      { id:'dine_in', icon:'🍽️', label:{ ar:'صالة', en:'Dine-in' } },
+      { id:'delivery', icon:'🚚', label:{ ar:'دليفري', en:'Delivery' } },
+      { id:'cashier', icon:'🧾', label:{ ar:'كاشير', en:'Counter' } }
+    ];
+
+    const TEXTS = {
+      ar:{
+        ui:{
+          shift:'الوردية', cashier:'الكاشير', dine_in:'صالة', delivery:'توصيل', cashier_mode:'كاشير',
+          search:'ابحث في المنيو', favorites:'المفضلة', favorites_only:'المفضلة فقط', categories:'التصنيفات', load_more:'عرض المزيد',
+          indexeddb:'قاعدة البيانات المحلية', last_sync:'آخر مزامنة', never_synced:'لم تتم', sync_now:'مزامنة الآن',
+          subtotal:'الإجمالي الفرعي', service:'خدمة', vat:'ضريبة', discount:'خصم', delivery_fee:'رسوم التوصيل', total:'الإجمالي المستحق',
+          cart_empty:'لم يتم إضافة أصناف بعد', choose_items:'اختر صنفًا من القائمة لإضافته إلى الطلب.', tables:'الطاولات',
+          select_table:'اختر طاولة لإسناد الطلب', table_status:'حالة الطاولة', table_available:'متاحة', table_occupied:'مشغولة',
+          table_reserved:'محجوزة', table_maintenance:'صيانة', payments:'المدفوعات', split_payments:'تقسيم الدفعات', paid:'المدفوع',
+          remaining:'المتبقي', open_payments:'تسجيل دفعة', open_reports:'فتح التقارير', reports:'التقارير', orders_count:'عدد الطلبات',
+          avg_ticket:'متوسط الفاتورة', top_selling:'الأكثر مبيعًا', sales_today:'مبيعات اليوم', save_order:'حفظ الطلب',
+          settle_and_print:'تحصيل وطباعة', print:'طباعة فقط', notes:'ملاحظات', discount_action:'خصم', clear:'مسح', new_order:'طلب جديد',
+          amount:'قيمة الدفعة', capture_payment:'تأكيد الدفع', close:'إغلاق', theme:'الثيم', light:'نهاري', dark:'ليلي', language:'اللغة',
+          arabic:'عربي', english:'English', service_type:'نوع الطلب', guests:'عدد الأفراد', kds:'نظام المطبخ (KDS)',
+          status_online:'متصل', status_offline:'غير متصل', status_idle:'انتظار', order_id:'طلب', last_orders:'الطلبات الأخيرة',
+          connect_kds:'اتصال', reconnect:'إعادة الاتصال'
+        },
+        toast:{
+          item_added:'تمت إضافة الصنف', quantity_updated:'تم تحديث الكمية', cart_cleared:'تم مسح الطلب',
+          order_saved:'تم حفظ الطلب محليًا', sync_complete:'تم تحديث المزامنة', payment_recorded:'تم تسجيل الدفعة',
+          amount_required:'من فضلك أدخل قيمة صحيحة', indexeddb_missing:'IndexedDB غير متاحة في هذا المتصفح',
+          indexeddb_error:'تعذر حفظ البيانات محليًا', print_stub:'سيتم التكامل مع الطابعة لاحقًا',
+          discount_stub:'سيتم تفعيل الخصومات لاحقًا', notes_updated:'تم تحديث الملاحظات', add_note:'أدخل ملاحظة ترسل للمطبخ',
+          set_qty:'أدخل الكمية الجديدة', line_actions:'سيتم فتح إجراءات السطر لاحقًا', confirm_clear:'هل تريد مسح الطلب الحالي؟',
+          new_order:'تم إنشاء طلب جديد', order_type_changed:'تم تغيير نوع الطلب', table_assigned:'تم اختيار الطاولة',
+          merge_stub:'قريبًا دمج الطاولات', load_more_stub:'سيتم تحميل المزيد من الأصناف لاحقًا', indexeddb_syncing:'جاري المزامنة مع IndexedDB',
+          theme_switched:'تم تغيير الثيم', lang_switched:'تم تغيير اللغة', logout_stub:'تم إنهاء الوردية افتراضيًا',
+          kdsConnected:'تم الاتصال بالمطبخ', kdsClosed:'تم إغلاق الاتصال بالمطبخ', kdsFailed:'فشل الاتصال بالمطبخ',
+          kdsUnavailable:'متصفحك لا يدعم WebSocket', kdsPong:'تم استقبال إشارة من المطبخ'
+        }
+      },
+      en:{
+        ui:{
+          shift:'Shift', cashier:'Cashier', dine_in:'Dine-in', delivery:'Delivery', cashier_mode:'Counter',
+          search:'Search menu', favorites:'Favorites', favorites_only:'Only favorites', categories:'Categories', load_more:'Load more',
+          indexeddb:'Local database', last_sync:'Last sync', never_synced:'Never', sync_now:'Sync now', subtotal:'Subtotal',
+          service:'Service', vat:'VAT', discount:'Discount', delivery_fee:'Delivery fee', total:'Amount due',
+          cart_empty:'No items added yet', choose_items:'Pick an item from the menu to start the order.', tables:'Tables',
+          select_table:'Select a table for this order', table_status:'Table status', table_available:'Available', table_occupied:'Occupied',
+          table_reserved:'Reserved', table_maintenance:'Maintenance', payments:'Payments', split_payments:'Split payments', paid:'Paid',
+          remaining:'Remaining', open_payments:'Add payment', open_reports:'Open reports', reports:'Reports', orders_count:'Orders',
+          avg_ticket:'Average ticket', top_selling:'Top seller', sales_today:'Sales today', save_order:'Save order',
+          settle_and_print:'Settle & print', print:'Print only', notes:'Notes', discount_action:'Discount', clear:'Clear',
+          new_order:'New order', amount:'Payment amount', capture_payment:'Capture payment', close:'Close', theme:'Theme',
+          light:'Light', dark:'Dark', language:'Language', arabic:'Arabic', english:'English', service_type:'Service type',
+          guests:'Guests', kds:'Kitchen display', status_online:'Online', status_offline:'Offline', status_idle:'Idle',
+          order_id:'Order', last_orders:'Recent orders', connect_kds:'Connect', reconnect:'Reconnect'
+        },
+        toast:{
+          item_added:'Item added to cart', quantity_updated:'Quantity updated', cart_cleared:'Cart cleared',
+          order_saved:'Order stored locally', sync_complete:'Sync completed', payment_recorded:'Payment recorded',
+          amount_required:'Enter a valid amount', indexeddb_missing:'IndexedDB is not available in this browser',
+          indexeddb_error:'Failed to persist locally', print_stub:'Printer integration coming soon',
+          discount_stub:'Discount workflow coming soon', notes_updated:'Notes updated', add_note:'Add a note for the kitchen',
+          set_qty:'Enter the new quantity', line_actions:'Line actions coming soon', confirm_clear:'Clear the current order?',
+          new_order:'New order created', order_type_changed:'Order type changed', table_assigned:'Table assigned',
+          merge_stub:'Table merge coming soon', load_more_stub:'Menu pagination coming soon', indexeddb_syncing:'Syncing with IndexedDB…',
+          theme_switched:'Theme updated', lang_switched:'Language updated', logout_stub:'Session ended (stub)',
+          kdsConnected:'Connected to kitchen', kdsClosed:'Kitchen connection closed', kdsFailed:'Kitchen connection failed',
+          kdsUnavailable:'WebSocket not supported', kdsPong:'KDS heartbeat received'
+        }
+      }
+    };
+
+    function getTexts(db){
+      return TEXTS[db.env.lang] || TEXTS.ar;
+    }
+
+    function localize(value, lang){
+      if(value == null) return '';
+      if(typeof value === 'string') return value;
+      if(typeof value === 'object'){
+        return value[lang] || value.ar || value.en || Object.values(value)[0] || '';
+      }
+      return String(value);
+    }
+
+    function getCurrency(db){
+      const lang = db.env.lang;
+      return currencyMap[lang] || currencyMap.ar || currencyMap.en || 'EGP';
+    }
+
+    function getLocale(db){
+      return db.env.lang === 'ar' ? 'ar-EG' : 'en-US';
+    }
+
+    function round(value){
+      return Math.round((Number(value) || 0) * 100) / 100;
+    }
+
+    function calculateTotals(lines, cfg, type){
+      const subtotal = (lines || []).reduce((sum, line)=> sum + (Number(line.qty)||0) * (Number(line.price)||0), 0);
+      const serviceRate = type === 'dine_in' ? (cfg.service_charge_rate || 0) : 0;
+      const service = subtotal * serviceRate;
+      const vatBase = subtotal + service;
+      const vat = vatBase * (cfg.tax_rate || 0);
+      const deliveryFee = type === 'delivery' ? (cfg.default_delivery_fee || 0) : 0;
+      const discount = 0;
+      const due = subtotal + service + vat + deliveryFee - discount;
+      return {
+        subtotal: round(subtotal),
+        service: round(service),
+        vat: round(vat),
+        discount: round(discount),
+        deliveryFee: round(deliveryFee),
+        due: round(due)
+      };
+    }
+
+    function createOrderLine(item, qty){
+      const quantity = qty || 1;
+      const price = Number(item.price) || 0;
+      return {
+        id: `line-${item.id}`,
+        itemId: item.id,
+        name: item.name,
+        description: item.description,
+        price,
+        qty: quantity,
+        total: round(price * quantity),
+        modifiers: [],
+        notes: ''
+      };
+    }
+
+    function filterMenu(menu, lang){
+      const term = (menu.search || '').trim().toLowerCase();
+      const favorites = new Set((menu.favorites || []).map(String));
+      return (menu.items || []).filter(item=>{
+        if(menu.showFavoritesOnly && !favorites.has(String(item.id))) return false;
+        const inCategory = menu.category === 'all' || item.category === menu.category;
+        if(!inCategory) return false;
+        if(!term) return true;
+        const name = localize(item.name, lang).toLowerCase();
+        const desc = localize(item.description, lang).toLowerCase();
+        return name.includes(term) || desc.includes(term);
+      });
+    }
+
+    function formatSync(ts, lang){
+      if(!ts) return null;
+      try{
+        const formatter = new Intl.DateTimeFormat(lang === 'ar' ? 'ar-EG' : 'en-GB', { hour:'2-digit', minute:'2-digit', second:'2-digit' });
+        return formatter.format(new Date(ts));
+      } catch(_){
+        return new Date(ts).toLocaleTimeString();
+      }
+    }
+
+    const hasIndexedDB = typeof window !== 'undefined' && typeof window.indexedDB !== 'undefined';
+
+    function createIndexedDBAdapter(name, version){
+      if(!hasIndexedDB){
+        return {
+          available:false,
+          async saveOrder(){ return false; },
+          async listOrders(){ return []; },
+          async markSync(){ return false; }
+        };
+      }
+      let dbPromise = null;
+      function openDB(){
+        if(dbPromise) return dbPromise;
+        dbPromise = new Promise((resolve, reject)=>{
+          const request = window.indexedDB.open(name, version);
+          request.onupgradeneeded = (event)=>{
+            const db = event.target.result;
+            if(!db.objectStoreNames.contains('orders')){
+              db.createObjectStore('orders', { keyPath:'id' });
+            }
+            if(!db.objectStoreNames.contains('syncLog')){
+              db.createObjectStore('syncLog', { keyPath:'ts' });
+            }
+          };
+          request.onsuccess = ()=> resolve(request.result);
+          request.onerror = ()=> reject(request.error);
+        });
+        return dbPromise;
+      }
+      async function saveOrder(order){
+        const db = await openDB();
+        return new Promise((resolve, reject)=>{
+          const tx = db.transaction('orders', 'readwrite');
+          tx.oncomplete = ()=> resolve(true);
+          tx.onerror = ()=> reject(tx.error);
+          tx.objectStore('orders').put({ id: order.id, updatedAt: Date.now(), status: order.status || 'draft', payload: order });
+        });
+      }
+      async function listOrders(){
+        const db = await openDB();
+        return new Promise((resolve, reject)=>{
+          const tx = db.transaction('orders', 'readonly');
+          const req = tx.objectStore('orders').getAll();
+          req.onsuccess = ()=> resolve(req.result || []);
+          req.onerror = ()=> reject(req.error);
+        });
+      }
+      async function markSync(){
+        const db = await openDB();
+        return new Promise((resolve, reject)=>{
+          const tx = db.transaction('syncLog', 'readwrite');
+          tx.oncomplete = ()=> resolve(true);
+          tx.onerror = ()=> reject(tx.error);
+          tx.objectStore('syncLog').put({ ts: Date.now() });
+        });
+      }
+      return { available:true, saveOrder, listOrders, markSync };
+    }
+
+    function createKDSBridge(url){
+      let socket = null;
+      return {
+        connect(ctx){
+          const state = ctx.getState();
+          const t = getTexts(state);
+          if(socket){
+            try { socket.close(); } catch(_){ }
+          }
+          if(!('WebSocket' in window)){
+            UI.pushToast(ctx, { title:t.toast.kdsUnavailable, icon:'⚠️' });
+            return;
+          }
+          ctx.setState(s=>({
+            ...s,
+            data:{
+              ...s.data,
+              status:{
+                ...s.data.status,
+                kds:{ ...(s.data.status?.kds || {}), state:'idle' }
+              }
+            }
+          }));
+          ctx.rebuild();
+          try{
+            socket = new WebSocket(url);
+          } catch(error){
+            UI.pushToast(ctx, { title:t.toast.kdsFailed, message:String(error), icon:'🛑' });
+            ctx.setState(s=>({
+              ...s,
+              data:{
+                ...s.data,
+                status:{ ...s.data.status, kds:{ ...(s.data.status?.kds || {}), state:'offline' } }
+              }
+            }));
+            ctx.rebuild();
+            return;
+          }
+          socket.onopen = ()=>{
+            UI.pushToast(ctx, { title:t.toast.kdsConnected, icon:'✅' });
+            ctx.setState(s=>({
+              ...s,
+              data:{
+                ...s.data,
+                status:{ ...s.data.status, kds:{ ...(s.data.status?.kds || {}), state:'online' } }
+              }
+            }));
+            ctx.rebuild();
+          };
+          socket.onclose = ()=>{
+            UI.pushToast(ctx, { title:t.toast.kdsClosed, icon:'ℹ️' });
+            ctx.setState(s=>({
+              ...s,
+              data:{
+                ...s.data,
+                status:{ ...s.data.status, kds:{ ...(s.data.status?.kds || {}), state:'offline' } }
+              }
+            }));
+            ctx.rebuild();
+          };
+          socket.onerror = ()=>{
+            UI.pushToast(ctx, { title:t.toast.kdsFailed, icon:'🛑' });
+            ctx.setState(s=>({
+              ...s,
+              data:{
+                ...s.data,
+                status:{ ...s.data.status, kds:{ ...(s.data.status?.kds || {}), state:'offline' } }
+              }
+            }));
+            ctx.rebuild();
+          };
+          socket.onmessage = (event)=>{
+            try{
+              const payload = JSON.parse(event.data);
+              if(payload && payload.type === 'pong'){
+                UI.pushToast(ctx, { title:'KDS', message:t.toast.kdsPong, icon:'🍳', ttl:1600 });
+              }
+            } catch(_){ }
+          };
+        }
+      };
+    }
+
+    const posDB = createIndexedDBAdapter('mishkah-pos', 1);
+    const kdsBridge = createKDSBridge('wss://signal.mas.com.eg/signaldata?id=96nnVOIawRs7Wo_XpAFM0Q');
+
+    const menuCategories = [{ id:'all', translations:{ ar:'الكل', en:'All' } }].concat(MOCK.categories || []);
+    const categories = menuCategories.map(cat=>({
+      id: cat.id,
+      label:{ ar: cat.translations?.ar || cat.id, en: cat.translations?.en || cat.id }
+    }));
+
+    const menuItems = (MOCK.items || []).map(item=>({
+      id: item.id,
+      category: item.category || 'all',
+      price: item.price || 0,
+      image: item.image,
+      name:{
+        ar: item.translations?.ar?.name || item.translations?.en?.name || String(item.id),
+        en: item.translations?.en?.name || item.translations?.ar?.name || String(item.id)
+      },
+      description:{
+        ar: item.translations?.ar?.description || '',
+        en: item.translations?.en?.description || item.translations?.ar?.description || ''
+      }
+    }));
+
+    const tables = (MOCK.tables || []).map(tbl=>({ ...tbl }));
+    const employees = MOCK.employees || [];
+    const cashier = employees[0] || { full_name:'أحمد محمود', role:'cashier' };
+
+    function generateOrderId(){
+      return 'ORD-' + Date.now().toString(36).toUpperCase();
+    }
+
+    const sampleLines = menuItems.length ? [
+      createOrderLine(menuItems[0], 2),
+      createOrderLine(menuItems[1] || menuItems[0], 1)
+    ] : [];
+
+    const initialTotals = calculateTotals(sampleLines, settings, 'dine_in');
+
+    const posState = {
+      head:{ title:'مشكاة — نقطة بيع حية' },
+      env:{ theme:'dark', lang:'ar', dir:'rtl' },
+      data:{
+        settings,
+        currency: currencyMap,
+        user:{
+          name: cashier.full_name || 'أحمد محمود',
+          role: cashier.role || 'cashier',
+          shift:'الصباحية',
+          shiftNo:'#103'
+        },
+        status:{
+          indexeddb:{ state: posDB.available ? 'idle' : 'offline', lastSync: null },
+          kds:{ state:'idle', endpoint:'wss://signal.mas.com.eg/signaldata?id=96nnVOIawRs7Wo_XpAFM0Q' }
+        },
+        menu:{
+          search:'',
+          category:'all',
+          showFavoritesOnly:false,
+          favorites:[],
+          categories,
+          items: menuItems
+        },
+        order:{
+          id: generateOrderId(),
+          type:'dine_in',
+          table: tables.find(t=> t.status === 'occupied') || tables[0] || null,
+          guests:3,
+          lines: sampleLines,
+          totals: initialTotals
+        },
+        tables,
+        payments:{
+          methods:[
+            { id:'cash', icon:'💵', label:{ ar:'نقدي', en:'Cash' } },
+            { id:'card', icon:'💳', label:{ ar:'بطاقة', en:'Card' } },
+            { id:'wallet', icon:'📱', label:{ ar:'محفظة', en:'Wallet' } },
+            { id:'voucher', icon:'🎟️', label:{ ar:'قسيمة', en:'Voucher' } }
+          ],
+          activeMethod:'cash',
+          split:[
+            { id:'pm-1', method:'cash', amount:250 },
+            { id:'pm-2', method:'card', amount:120 }
+          ]
+        },
+        reports:{
+          salesToday:12430,
+          ordersCount:58,
+          avgTicket:214,
+          topItemId: menuItems[0]?.id || null
+        }
+      },
+      ui:{
+        modals:{ tables:false, payments:false, reports:false },
+        drawers:{},
+        paymentDraft:{ amount:'' }
+      }
+    };
+
+    function getOrderTypeConfig(type){
+      return ORDER_TYPES.find(o=> o.id === type) || ORDER_TYPES[0];
+    }
+
+    function statusBadge(db, state, label){
+      const t = getTexts(db);
+      const tone = state === 'online' ? 'status/online' : state === 'offline' ? 'status/offline' : 'status/idle';
+      const stateText = state === 'online' ? t.ui.status_online : state === 'offline' ? t.ui.status_offline : t.ui.status_idle;
+      return UI.Badge({
+        variant:'badge/status',
+        attrs:{ class: tw`${token(tone)} text-xs` },
+        leading: state === 'online' ? '●' : state === 'offline' ? '✖' : '…',
+        text: `${label} • ${stateText}`
+      });
+    }
+
+    function ThemeSwitch(db){
+      const t = getTexts(db);
+      return UI.Segmented({
+        items:[
+          { id:'light', label:`☀️ ${t.ui.light}`, attrs:{ gkey:'pos:theme:toggle', 'data-theme':'light' } },
+          { id:'dark', label:`🌙 ${t.ui.dark}`, attrs:{ gkey:'pos:theme:toggle', 'data-theme':'dark' } }
+        ],
+        activeId: db.env.theme,
+        attrs:{ class: tw`hidden xl:inline-flex` }
+      });
+    }
+
+    function LangSwitch(db){
+      const t = getTexts(db);
+      return UI.Segmented({
+        items:[
+          { id:'ar', label:t.ui.arabic, attrs:{ gkey:'pos:lang:switch', 'data-lang':'ar' } },
+          { id:'en', label:t.ui.english, attrs:{ gkey:'pos:lang:switch', 'data-lang':'en' } }
+        ],
+        activeId: db.env.lang
+      });
+    }
+
+    function Header(db){
+      const t = getTexts(db);
+      const user = db.data.user;
+      const orderType = getOrderTypeConfig(db.data.order.type);
+      return UI.Toolbar({
+        left:[
+          D.Text.Span({ attrs:{ class: tw`text-2xl font-black tracking-tight` }}, ['Mishkah POS']),
+          UI.Badge({ text:`${orderType.icon} ${localize(orderType.label, db.env.lang)}`, variant:'badge/ghost', attrs:{ class: tw`text-sm` } })
+        ],
+        right:[
+          ThemeSwitch(db),
+          LangSwitch(db),
+          UI.Badge({ text:`${t.ui.shift}: ${user.shift}`, leading:'🕑', variant:'badge/ghost' }),
+          UI.Badge({ text:`${t.ui.cashier}: ${user.name}`, leading:'👤', variant:'badge/ghost' }),
+          UI.Button({ attrs:{ gkey:'pos:session:logout' }, variant:'ghost', size:'sm' }, ['🚪'])
+        ]
+      });
+    }
+
+    function MenuItemCard(db, item){
+      const lang = db.env.lang;
+      const menu = db.data.menu;
+      const isFav = (menu.favorites || []).includes(String(item.id));
+      return D.Containers.Div({
+        attrs:{
+          class: tw`relative flex flex-col gap-2 rounded-3xl border border-[var(--border)] bg-[var(--surface-1)] p-3 text-[var(--foreground)] transition hover:border-[var(--primary)] focus-within:ring-2 focus-within:ring-[var(--primary)]`,
+          gkey:'pos:menu:add',
+          'data-item-id': item.id,
+          role:'button',
+          tabindex:'0'
+        }
+      }, [
+        UI.Button({
+          attrs:{
+            gkey:'pos:menu:favorite',
+            'data-item-id': item.id,
+            class: tw`absolute top-2 ${db.env.dir === 'rtl' ? 'left-2' : 'right-2'} rounded-full`
+          },
+          variant: isFav ? 'solid' : 'ghost',
+          size:'sm'
+        }, [isFav ? '★' : '☆']),
+        D.Containers.Div({ attrs:{ class: tw`h-24 overflow-hidden rounded-2xl bg-[var(--surface-2)]` }}, [
+          item.image
+            ? D.Containers.Img({ attrs:{ src:item.image, alt:localize(item.name, lang), class: tw`h-full w-full object-cover scale-[1.05]` }})
+            : D.Containers.Div({ attrs:{ class: tw`grid h-full place-items-center text-3xl` }}, ['🍽️'])
+        ]),
+        D.Containers.Div({ attrs:{ class: tw`space-y-1` }}, [
+          D.Text.Strong({ attrs:{ class: tw`text-sm font-semibold leading-tight` }}, [localize(item.name, lang)]),
+          localize(item.description, lang)
+            ? D.Text.P({ attrs:{ class: tw`text-xs ${token('muted')} line-clamp-2` }}, [localize(item.description, lang)])
+            : null
+        ].filter(Boolean)),
+        D.Containers.Div({ attrs:{ class: tw`mt-auto flex items-center justify-between text-sm` }}, [
+          UI.PriceText({ amount:item.price, currency:getCurrency(db), locale:getLocale(db) }),
+          D.Text.Span({ attrs:{ class: tw`text-xl font-semibold text-[var(--primary)]` }}, ['+'])
+        ])
+      ]);
+    }
+
+    function MenuColumn(db){
+      const t = getTexts(db);
+      const lang = db.env.lang;
+      const menu = db.data.menu;
+      const filtered = filterMenu(menu, lang);
+      const chips = menu.categories.map(cat=>({
+        id: cat.id,
+        label: localize(cat.label, lang),
+        attrs:{ gkey:'pos:menu:category', 'data-category-id':cat.id }
+      }));
+      return D.Containers.Section({ attrs:{ class: tw`flex h-full flex-col gap-3 overflow-hidden` }}, [
+        UI.Card({
+          variant:'card/soft-1',
+          content: D.Containers.Div({ attrs:{ class: tw`flex flex-col gap-3` }}, [
+            UI.SearchBar({
+              value: menu.search,
+              placeholder: t.ui.search,
+              onInput:'pos:menu:search',
+              trailing:[
+                UI.Button({
+                  attrs:{
+                    gkey:'pos:menu:favorites-only',
+                    class: tw`rounded-full ${menu.showFavoritesOnly ? 'bg-[var(--primary)] text-white' : ''}`
+                  },
+                  variant: menu.showFavoritesOnly ? 'solid' : 'ghost',
+                  size:'sm'
+                }, ['⭐'])
+              ]
+            }),
+            UI.ChipGroup({ items: chips, activeId: menu.category })
+          ])
+        }),
+        D.Containers.Section({ attrs:{ class: tw`${token('scroll-panel')} flex-1 overflow-hidden` }}, [
+          D.Containers.Div({ attrs:{ class: tw`${token('scroll-panel/head')}` }}, [
+            D.Text.Strong({}, [t.ui.categories]),
+            UI.Button({ attrs:{ gkey:'pos:menu:load-more' }, variant:'ghost', size:'sm' }, [t.ui.load_more])
+          ]),
+          UI.ScrollArea({
+            attrs:{ class: tw`${token('scroll-panel/body')} px-3 pb-3` },
+            children:[
+              filtered.length
+                ? D.Containers.Div({ attrs:{ class: tw`grid grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-3` }}, filtered.map(item=> MenuItemCard(db, item)))
+                : UI.EmptyState({ icon:'🍽️', title:t.ui.cart_empty, description:t.ui.choose_items })
+            ]
+          }),
+          D.Containers.Div({ attrs:{ class: tw`${token('scroll-panel/footer')} flex flex-wrap items-center justify-between gap-3` }}, [
+            statusBadge(db, db.data.status.indexeddb.state, t.ui.indexeddb),
+            D.Containers.Div({ attrs:{ class: tw`text-xs ${token('muted')}` }}, [
+              D.Text.Span({}, [`${t.ui.last_sync}: ${formatSync(db.data.status.indexeddb.lastSync, lang) || t.ui.never_synced}`])
+            ]),
+            UI.Button({ attrs:{ gkey:'pos:indexeddb:sync' }, variant:'ghost', size:'sm' }, [t.ui.sync_now])
+          ])
+        ])
+      ]);
+    }
+
+    function OrderLine(db, line){
+      const lang = db.env.lang;
+      return UI.ListItem({
+        leading: D.Text.Span({ attrs:{ class: tw`text-lg` }}, ['🍲']),
+        content:[
+          D.Text.Strong({}, [localize(line.name, lang)]),
+          line.notes ? D.Text.Span({ attrs:{ class: tw`text-xs ${token('muted')}` }}, ['📝 ', line.notes]) : null
+        ].filter(Boolean),
+        trailing:[
+          UI.QtyStepper({ value: line.qty, gkeyDec:'pos:order:line:dec', gkeyInc:'pos:order:line:inc', gkeyEdit:'pos:order:line:qty', dataId: line.id }),
+          UI.PriceText({ amount: line.total, currency:getCurrency(db), locale:getLocale(db) }),
+          UI.Button({ attrs:{ gkey:'pos:order:line:actions', 'data-line-id':line.id }, variant:'ghost', size:'sm' }, ['⋯'])
+        ]
+      });
+    }
+
+    function TotalsSection(db){
+      const t = getTexts(db);
+      const totals = db.data.order.totals || {};
+      const rows = [
+        { label:t.ui.subtotal, value: totals.subtotal },
+        { label:t.ui.service, value: totals.service },
+        { label:t.ui.vat, value: totals.vat },
+        totals.deliveryFee ? { label:t.ui.delivery_fee, value: totals.deliveryFee } : null,
+        totals.discount ? { label:t.ui.discount, value: totals.discount } : null
+      ].filter(Boolean);
+      return D.Containers.Div({ attrs:{ class: tw`space-y-2` }}, [
+        ...rows.map(row=> UI.HStack({ attrs:{ class: tw`${token('split')} text-sm` }}, [
+          D.Text.Span({ attrs:{ class: tw`${token('muted')}` }}, [row.label]),
+          UI.PriceText({ amount:row.value, currency:getCurrency(db), locale:getLocale(db) })
+        ])),
+        UI.Divider(),
+        UI.HStack({ attrs:{ class: tw`${token('split')} text-lg font-semibold` }}, [
+          D.Text.Span({}, [t.ui.total]),
+          UI.PriceText({ amount:totals.due, currency:getCurrency(db), locale:getLocale(db) })
+        ])
+      ]);
+    }
+
+    function PaymentSummary(db){
+      const t = getTexts(db);
+      const split = db.data.payments.split || [];
+      const methods = db.data.payments.methods || [];
+      const due = db.data.order.totals?.due || 0;
+      const totalPaid = split.reduce((sum, entry)=> sum + (Number(entry.amount)||0), 0);
+      const remaining = Math.max(0, round(due - totalPaid));
+      return UI.Card({
+        variant:'card/soft-1',
+        title: t.ui.split_payments,
+        content: D.Containers.Div({ attrs:{ class: tw`space-y-2` }}, [
+          ...split.map(entry=>{
+            const method = methods.find(m=> m.id === entry.method);
+            const label = method ? `${method.icon} ${localize(method.label, db.env.lang)}` : entry.method;
+            return UI.HStack({ attrs:{ class: tw`${token('split')} text-sm` }}, [
+              D.Text.Span({}, [label]),
+              UI.PriceText({ amount: entry.amount, currency:getCurrency(db), locale:getLocale(db) })
+            ]);
+          }),
+          split.length ? UI.Divider() : null,
+          UI.HStack({ attrs:{ class: tw`${token('split')} text-sm font-semibold` }}, [
+            D.Text.Span({}, [t.ui.paid]),
+            UI.PriceText({ amount: totalPaid, currency:getCurrency(db), locale:getLocale(db) })
+          ]),
+          UI.HStack({ attrs:{ class: tw`${token('split')} text-sm` }}, [
+            D.Text.Span({ attrs:{ class: tw`${token('muted')}` }}, [t.ui.remaining]),
+            UI.PriceText({ amount: remaining, currency:getCurrency(db), locale:getLocale(db) })
+          ]),
+          UI.Button({ attrs:{ gkey:'pos:payments:open', class: tw`w-full` }, variant:'soft', size:'sm' }, [t.ui.open_payments])
+        ].filter(Boolean))
+      });
+    }
+
+    function OrderColumn(db){
+      const t = getTexts(db);
+      const order = db.data.order;
+      const serviceSegments = ORDER_TYPES.map(type=>({
+        id: type.id,
+        label: `${type.icon} ${localize(type.label, db.env.lang)}`,
+        attrs:{ gkey:'pos:order:type', 'data-order-type':type.id }
+      }));
+      return D.Containers.Section({ attrs:{ class: tw`flex h-full flex-col gap-3 overflow-hidden` }}, [
+        UI.Card({
+          variant:'card/soft-1',
+          content: D.Containers.Div({ attrs:{ class: tw`flex h-full flex-col gap-3` }}, [
+            UI.Segmented({ items: serviceSegments, activeId: order.type }),
+            D.Containers.Div({ attrs:{ class: tw`flex flex-wrap items-center justify-between gap-2 text-xs sm:text-sm ${token('muted')}` }}, [
+              D.Text.Span({}, [`${t.ui.order_id} ${order.id}`]),
+              order.type === 'dine_in'
+                ? D.Text.Span({}, [`${t.ui.tables}: ${order.table ? order.table.name : t.ui.select_table}`])
+                : D.Text.Span({}, [localize(getOrderTypeConfig(order.type).label, db.env.lang)]),
+              D.Text.Span({}, [`${t.ui.guests}: ${order.guests}`])
+            ]),
+            UI.ScrollArea({
+              attrs:{ class: tw`flex-1 overflow-auto pr-2` },
+              children:[
+                order.lines && order.lines.length
+                  ? UI.List({ children: order.lines.map(line=> OrderLine(db, line)) })
+                  : UI.EmptyState({ icon:'🧺', title:t.ui.cart_empty, description:t.ui.choose_items })
+              ]
+            }),
+            TotalsSection(db),
+            UI.HStack({ attrs:{ class: tw`gap-2` }}, [
+              UI.Button({ attrs:{ gkey:'pos:order:discount', class: tw`flex-1` }, variant:'ghost', size:'sm' }, [t.ui.discount_action]),
+              UI.Button({ attrs:{ gkey:'pos:order:note', class: tw`flex-1` }, variant:'ghost', size:'sm' }, [t.ui.notes]),
+              UI.Button({ attrs:{ gkey:'pos:order:new', class: tw`flex-1` }, variant:'ghost', size:'sm' }, [t.ui.new_order]),
+              UI.Button({ attrs:{ gkey:'pos:order:clear' }, variant:'ghost', size:'sm' }, [t.ui.clear])
+            ])
+          ])
+        }),
+        PaymentSummary(db),
+        UI.StatCard({
+          title: t.ui.reports,
+          value: `${new Intl.NumberFormat(getLocale(db)).format(db.data.reports.salesToday)} ${getCurrency(db)}`,
+          meta: `${t.ui.orders_count}: ${db.data.reports.ordersCount}`,
+          footer:[
+            UI.Button({ attrs:{ gkey:'pos:reports:toggle', class: tw`w-full` }, variant:'ghost', size:'sm' }, [t.ui.open_reports])
+          ]
+        })
+      ]);
+    }
+
+    function FooterBar(db){
+      const t = getTexts(db);
+      return UI.Footerbar({
+        left:[
+          statusBadge(db, db.data.status.kds.state, t.ui.kds),
+          statusBadge(db, db.data.status.indexeddb.state, t.ui.indexeddb)
+        ],
+        right:[
+          UI.Button({ attrs:{ gkey:'pos:order:save', class: tw`min-w-[140px]` }, variant:'soft', size:'md' }, [t.ui.save_order]),
+          UI.Button({ attrs:{ gkey:'pos:payments:open', class: tw`min-w-[160px]` }, variant:'solid', size:'md' }, [t.ui.settle_and_print]),
+          UI.Button({ attrs:{ gkey:'pos:order:print', class: tw`min-w-[120px]` }, variant:'ghost', size:'md' }, [t.ui.print])
+        ]
+      });
+    }
+
+    function TablesModal(db){
+      const t = getTexts(db);
+      if(!db.ui.modals.tables) return null;
+      const tablesList = db.data.tables || [];
+      return UI.Modal({
+        open:true,
+        title:t.ui.tables,
+        description:t.ui.select_table,
+        actions:[
+          UI.ScrollArea({
+            attrs:{ class: tw`max-h-[60vh] w-full space-y-2` },
+            children: tablesList.map(table=>{
+              const statusMap = {
+                available:{ icon:'🟢', tone:'online', label:t.ui.table_available },
+                occupied:{ icon:'🟠', tone:'idle', label:t.ui.table_occupied },
+                reserved:{ icon:'🔵', tone:'idle', label:t.ui.table_reserved },
+                maintenance:{ icon:'⚫', tone:'offline', label:t.ui.table_maintenance }
+              };
+              const meta = statusMap[table.status] || statusMap.available;
+              return UI.ListItem({
+                leading: D.Text.Span({ attrs:{ class: tw`text-lg` }}, [meta.icon]),
+                content:[
+                  D.Text.Strong({}, [table.name || table.id]),
+                  D.Text.Span({ attrs:{ class: tw`text-xs ${token('muted')}` }}, [`${t.ui.guests}: ${table.seats}`]),
+                  meta.label ? D.Text.Span({ attrs:{ class: tw`text-xs ${token('muted')}` }}, [meta.label]) : null
+                ].filter(Boolean),
+                trailing:[ statusBadge(db, meta.tone === 'online' ? 'online' : meta.tone === 'offline' ? 'offline' : 'idle', t.ui.table_status) ],
+                attrs:{ gkey:'pos:tables:select', 'data-table-id':table.id }
+              });
+            })
+          }),
+          UI.Button({ attrs:{ gkey:'ui:modal:close', class: tw`w-full` }, variant:'ghost', size:'sm' }, [t.ui.close])
+        ]
+      });
+    }
+
+    function PaymentsSheet(db){
+      const t = getTexts(db);
+      if(!db.ui.modals.payments) return null;
+      return UI.Drawer({
+        open:true,
+        side:'end',
+        header: D.Containers.Div({ attrs:{ class: tw`flex items-center justify-between gap-2` }}, [
+          D.Containers.Div({ attrs:{ class: tw`space-y-1` }}, [
+            D.Text.Strong({}, [t.ui.payments]),
+            D.Text.Span({ attrs:{ class: tw`text-xs ${token('muted')}` }}, [t.ui.split_payments])
+          ]),
+          UI.Button({ attrs:{ gkey:'pos:payments:close' }, variant:'ghost', size:'sm' }, [t.ui.close])
+        ]),
+        content: D.Containers.Div({ attrs:{ class: tw`space-y-3` }}, [
+          UI.ChipGroup({
+            items: (db.data.payments.methods || []).map(method=>({
+              id: method.id,
+              label: `${method.icon} ${localize(method.label, db.env.lang)}`,
+              attrs:{ gkey:'pos:payments:method', 'data-method-id':method.id }
+            })),
+            activeId: db.data.payments.activeMethod
+          }),
+          UI.Input({ attrs:{
+            type:'number',
+            min:'0',
+            step:'0.01',
+            value: db.ui.paymentDraft?.amount || '',
+            placeholder: t.ui.amount,
+            gkey:'pos:payments:amount'
+          }}),
+          UI.Button({ attrs:{ gkey:'pos:payments:capture', class: tw`w-full` }, variant:'solid', size:'md' }, [t.ui.capture_payment])
+        ])
+      });
+    }
+
+    function ReportsDrawer(db){
+      const t = getTexts(db);
+      if(!db.ui.modals.reports) return null;
+      const topItem = db.data.reports.topItemId ? (db.data.menu.items || []).find(it=> it.id === db.data.reports.topItemId) : null;
+      return UI.Drawer({
+        open:true,
+        side:'start',
+        header: D.Containers.Div({ attrs:{ class: tw`flex items-center justify-between` }}, [
+          D.Text.Strong({}, [t.ui.reports]),
+          UI.Button({ attrs:{ gkey:'pos:reports:toggle' }, variant:'ghost', size:'sm' }, ['×'])
+        ]),
+        content: D.Containers.Div({ attrs:{ class: tw`space-y-3` }}, [
+          UI.StatCard({ title: t.ui.sales_today, value: `${new Intl.NumberFormat(getLocale(db)).format(db.data.reports.salesToday)} ${getCurrency(db)}` }),
+          UI.StatCard({ title: t.ui.orders_count, value: String(db.data.reports.ordersCount) }),
+          UI.StatCard({ title: t.ui.avg_ticket, value: `${new Intl.NumberFormat(getLocale(db)).format(db.data.reports.avgTicket)} ${getCurrency(db)}` }),
+          topItem ? UI.StatCard({ title: t.ui.top_selling, value: localize(topItem.name, db.env.lang) }) : null
+        ].filter(Boolean))
+      });
+    }
+
+    Mishkah.app.setBody(function(db){
+      return UI.AppRoot({
+        shell: D.Containers.Div({ attrs:{ class: tw`pos-shell flex h-full flex-col overflow-hidden bg-[var(--background)] text-[var(--foreground)]` }}, [
+          Header(db),
+          D.Containers.Main({ attrs:{ class: tw`flex-1 grid gap-4 px-4 pb-3 pt-3 lg:grid-cols-[minmax(0,2.4fr)_minmax(0,1fr)] overflow-hidden` }}, [
+            MenuColumn(db),
+            OrderColumn(db)
+          ]),
+          FooterBar(db)
+        ]),
+        overlays:[
+          TablesModal(db),
+          PaymentsSheet(db),
+          ReportsDrawer(db),
+          db.ui?.toasts ? UI.ToastHost({ toasts: db.ui.toasts }) : null
+        ].filter(Boolean)
+      });
+    });
+
+    const app = M.app.createApp(posState, {});
+    const auto = U.twcss.auto(posState, app, { pageScaffold:true });
+
+    const posOrders = {
+      'pos.menu.search':{
+        on:['input','change'],
+        gkeys:['pos:menu:search'],
+        handler:(e,ctx)=>{
+          const value = e.target.value || '';
+          ctx.setState(s=>({
+            ...s,
+            data:{
+              ...s.data,
+              menu:{ ...(s.data.menu || {}), search:value }
+            }
+          }));
+          ctx.rebuild();
+        }
+      },
+      'pos.menu.category':{
+        on:['click'],
+        gkeys:['pos:menu:category'],
+        handler:(e,ctx)=>{
+          const btn = e.target.closest('[data-category-id]');
+          if(!btn) return;
+          const id = btn.getAttribute('data-category-id') || 'all';
+          ctx.setState(s=>({
+            ...s,
+            data:{
+              ...s.data,
+              menu:{ ...(s.data.menu || {}), category:id }
+            }
+          }));
+          ctx.rebuild();
+        }
+      },
+      'pos.menu:add':{
+        on:['click','keydown'],
+        gkeys:['pos:menu:add'],
+        handler:(e,ctx)=>{
+          if(e.type === 'keydown' && !['Enter',' '].includes(e.key)) return;
+          const card = e.target.closest('[data-item-id]');
+          if(!card) return;
+          const itemId = card.getAttribute('data-item-id');
+          const state = ctx.getState();
+          const item = (state.data.menu.items || []).find(it=> String(it.id) === String(itemId));
+          if(!item) return;
+          const t = getTexts(state);
+          ctx.setState(s=>{
+            const data = s.data || {};
+            const order = data.order || {};
+            const lines = (order.lines || []).map(line=> ({ ...line }));
+            const idx = lines.findIndex(line=> String(line.itemId) === String(item.id));
+            if(idx >= 0){
+              const line = { ...lines[idx] };
+              line.qty += 1;
+              line.total = round(line.qty * line.price);
+              lines[idx] = line;
+            } else {
+              lines.push(createOrderLine(item, 1));
+            }
+            const totals = calculateTotals(lines, data.settings || {}, order.type);
+            return {
+              ...s,
+              data:{
+                ...data,
+                order:{ ...order, lines, totals }
+              }
+            };
+          });
+          ctx.rebuild();
+          UI.pushToast(ctx, { title:t.toast.item_added, icon:'✅' });
+        }
+      },
+      'pos.menu.favorite':{
+        on:['click'],
+        gkeys:['pos:menu:favorite'],
+        handler:(e,ctx)=>{
+          e.preventDefault();
+          e.stopPropagation();
+          const btn = e.target.closest('[data-item-id]');
+          if(!btn) return;
+          const itemId = String(btn.getAttribute('data-item-id'));
+          ctx.setState(s=>{
+            const menu = s.data.menu || {};
+            const favorites = new Set((menu.favorites || []).map(String));
+            if(favorites.has(itemId)) favorites.delete(itemId); else favorites.add(itemId);
+            return {
+              ...s,
+              data:{
+                ...s.data,
+                menu:{ ...menu, favorites:Array.from(favorites) }
+              }
+            };
+          });
+          ctx.rebuild();
+        }
+      },
+      'pos.menu.favorites-only':{
+        on:['click'],
+        gkeys:['pos:menu:favorites-only'],
+        handler:(e,ctx)=>{
+          ctx.setState(s=>({
+            ...s,
+            data:{
+              ...s.data,
+              menu:{ ...(s.data.menu || {}), showFavoritesOnly: !s.data.menu?.showFavoritesOnly }
+            }
+          }));
+          ctx.rebuild();
+        }
+      },
+      'pos.menu.load-more':{
+        on:['click'],
+        gkeys:['pos:menu:load-more'],
+        handler:(e,ctx)=>{
+          const t = getTexts(ctx.getState());
+          UI.pushToast(ctx, { title:t.toast.load_more_stub, icon:'ℹ️' });
+        }
+      },
+      'pos.order.line.inc':{
+        on:['click'],
+        gkeys:['pos:order:line:inc'],
+        handler:(e,ctx)=>{
+          const btn = e.target.closest('[data-line-id]');
+          if(!btn) return;
+          const lineId = btn.getAttribute('data-line-id');
+          ctx.setState(s=>{
+            const data = s.data || {};
+            const order = data.order || {};
+            const lines = (order.lines || []).map(line=>{
+              if(line.id !== lineId) return line;
+              const next = { ...line, qty: line.qty + 1 };
+              next.total = round(next.qty * next.price);
+              return next;
+            });
+            const totals = calculateTotals(lines, data.settings || {}, order.type);
+            return {
+              ...s,
+              data:{
+                ...data,
+                order:{ ...order, lines, totals }
+              }
+            };
+          });
+          ctx.rebuild();
+        }
+      },
+      'pos.order.line.dec':{
+        on:['click'],
+        gkeys:['pos:order:line:dec'],
+        handler:(e,ctx)=>{
+          const btn = e.target.closest('[data-line-id]');
+          if(!btn) return;
+          const lineId = btn.getAttribute('data-line-id');
+          ctx.setState(s=>{
+            const data = s.data || {};
+            const order = data.order || {};
+            const lines = [];
+            for(const line of (order.lines || [])){
+              if(line.id !== lineId){
+                lines.push(line);
+                continue;
+              }
+              if(line.qty <= 1) continue;
+              const next = { ...line, qty: line.qty - 1 };
+              next.total = round(next.qty * next.price);
+              lines.push(next);
+            }
+            const totals = calculateTotals(lines, data.settings || {}, order.type);
+            return {
+              ...s,
+              data:{
+                ...data,
+                order:{ ...order, lines, totals }
+              }
+            };
+          });
+          ctx.rebuild();
+        }
+      },
+      'pos.order.line.qty':{
+        on:['click'],
+        gkeys:['pos:order:line:qty'],
+        handler:(e,ctx)=>{
+          const btn = e.target.closest('[data-line-id]');
+          if(!btn) return;
+          const lineId = btn.getAttribute('data-line-id');
+          const state = ctx.getState();
+          const t = getTexts(state);
+          const current = (state.data.order.lines || []).find(line=> line.id === lineId);
+          const nextValue = window.prompt(t.toast.set_qty, current ? current.qty : 1);
+          if(nextValue == null) return;
+          const qty = Math.max(1, parseInt(nextValue, 10) || 1);
+          ctx.setState(s=>{
+            const data = s.data || {};
+            const order = data.order || {};
+            const lines = (order.lines || []).map(line=>{
+              if(line.id !== lineId) return line;
+              const next = { ...line, qty };
+              next.total = round(next.qty * next.price);
+              return next;
+            });
+            const totals = calculateTotals(lines, data.settings || {}, order.type);
+            return {
+              ...s,
+              data:{
+                ...data,
+                order:{ ...order, lines, totals }
+              }
+            };
+          });
+          ctx.rebuild();
+        }
+      },
+      'pos.order.line.actions':{
+        on:['click'],
+        gkeys:['pos:order:line:actions'],
+        handler:(e,ctx)=>{
+          const t = getTexts(ctx.getState());
+          UI.pushToast(ctx, { title:t.toast.line_actions, icon:'🛠️' });
+        }
+      },
+      'pos.order.clear':{
+        on:['click'],
+        gkeys:['pos:order:clear'],
+        handler:(e,ctx)=>{
+          const t = getTexts(ctx.getState());
+          if(!window.confirm(t.toast.confirm_clear)) return;
+          ctx.setState(s=>{
+            const data = s.data || {};
+            const order = data.order || {};
+            const totals = calculateTotals([], data.settings || {}, order.type);
+            return {
+              ...s,
+              data:{
+                ...data,
+                order:{ ...order, lines:[], totals }
+              }
+            };
+          });
+          ctx.rebuild();
+          UI.pushToast(ctx, { title:t.toast.cart_cleared, icon:'🧺' });
+        }
+      },
+      'pos.order.new':{
+        on:['click'],
+        gkeys:['pos:order:new'],
+        handler:(e,ctx)=>{
+          const t = getTexts(ctx.getState());
+          ctx.setState(s=>{
+            const data = s.data || {};
+            const order = data.order || {};
+            const totals = calculateTotals([], data.settings || {}, order.type);
+            return {
+              ...s,
+              data:{
+                ...data,
+                order:{ ...order, id: generateOrderId(), lines:[], totals }
+              }
+            };
+          });
+          ctx.rebuild();
+          UI.pushToast(ctx, { title:t.toast.new_order, icon:'🆕' });
+        }
+      },
+      'pos.order.discount':{
+        on:['click'],
+        gkeys:['pos:order:discount'],
+        handler:(e,ctx)=>{
+          const t = getTexts(ctx.getState());
+          UI.pushToast(ctx, { title:t.toast.discount_stub, icon:'💡' });
+        }
+      },
+      'pos.order.note':{
+        on:['click'],
+        gkeys:['pos:order:note'],
+        handler:(e,ctx)=>{
+          const state = ctx.getState();
+          const t = getTexts(state);
+          const note = window.prompt(t.toast.add_note);
+          if(note == null) return;
+          ctx.setState(s=>{
+            const data = s.data || {};
+            const order = data.order || {};
+            const lines = (order.lines || []).map(line=> ({ ...line, notes: note }));
+            return {
+              ...s,
+              data:{
+                ...data,
+                order:{ ...order, lines }
+              }
+            };
+          });
+          ctx.rebuild();
+          UI.pushToast(ctx, { title:t.toast.notes_updated, icon:'📝' });
+        }
+      },
+      'pos.order.type':{
+        on:['click'],
+        gkeys:['pos:order:type'],
+        handler:(e,ctx)=>{
+          const btn = e.target.closest('[data-order-type]');
+          if(!btn) return;
+          const type = btn.getAttribute('data-order-type');
+          const t = getTexts(ctx.getState());
+          ctx.setState(s=>{
+            const data = s.data || {};
+            const order = data.order || {};
+            const lines = order.lines || [];
+            const nextOrder = { ...order, type };
+            if(type !== 'dine_in') nextOrder.table = null;
+            nextOrder.totals = calculateTotals(lines, data.settings || {}, type);
+            return {
+              ...s,
+              data:{
+                ...data,
+                order: nextOrder
+              }
+            };
+          });
+          ctx.rebuild();
+          UI.pushToast(ctx, { title:t.toast.order_type_changed, icon:'🔄' });
+        }
+      },
+      'pos.order.save':{
+        on:['click'],
+        gkeys:['pos:order:save'],
+        handler: async (e,ctx)=>{
+          const state = ctx.getState();
+          const t = getTexts(state);
+          if(!posDB.available){
+            UI.pushToast(ctx, { title:t.toast.indexeddb_missing, icon:'⚠️' });
+            return;
+          }
+          try{
+            await posDB.saveOrder(state.data.order);
+            await posDB.markSync();
+            ctx.setState(s=>({
+              ...s,
+              data:{
+                ...s.data,
+                status:{
+                  ...s.data.status,
+                  indexeddb:{ state:'online', lastSync: Date.now() }
+                }
+              }
+            }));
+            ctx.rebuild();
+            UI.pushToast(ctx, { title:t.toast.order_saved, icon:'💾' });
+          } catch(error){
+            UI.pushToast(ctx, { title:t.toast.indexeddb_error, message:String(error), icon:'🛑' });
+            ctx.setState(s=>({
+              ...s,
+              data:{
+                ...s.data,
+                status:{
+                  ...s.data.status,
+                  indexeddb:{ state:'offline', lastSync: s.data.status?.indexeddb?.lastSync || null }
+                }
+              }
+            }));
+            ctx.rebuild();
+          }
+        }
+      },
+      'pos.order.print':{
+        on:['click'],
+        gkeys:['pos:order:print'],
+        handler:(e,ctx)=>{
+          const t = getTexts(ctx.getState());
+          UI.pushToast(ctx, { title:t.toast.print_stub, icon:'🖨️' });
+        }
+      },
+      'pos.tables.open':{
+        on:['click'],
+        gkeys:['pos:tables:open'],
+        handler:(e,ctx)=>{
+          ctx.setState(s=>({
+            ...s,
+            ui:{ ...(s.ui || {}), modals:{ ...(s.ui?.modals || {}), tables:true } }
+          }));
+          ctx.rebuild();
+        }
+      },
+      'pos.tables.select':{
+        on:['click'],
+        gkeys:['pos:tables:select'],
+        handler:(e,ctx)=>{
+          const btn = e.target.closest('[data-table-id]');
+          if(!btn) return;
+          const tableId = btn.getAttribute('data-table-id');
+          const state = ctx.getState();
+          const table = (state.data.tables || []).find(t=> t.id === tableId) || null;
+          const t = getTexts(state);
+          ctx.setState(s=>({
+            ...s,
+            data:{
+              ...s.data,
+              order:{
+                ...(s.data.order || {}),
+                table,
+                totals: calculateTotals(s.data.order?.lines || [], s.data.settings || {}, s.data.order?.type || 'dine_in')
+              }
+            },
+            ui:{ ...(s.ui || {}), modals:{ ...(s.ui?.modals || {}), tables:false } }
+          }));
+          ctx.rebuild();
+          UI.pushToast(ctx, { title:t.toast.table_assigned, icon:'🪑' });
+        }
+      },
+      'pos.tables.merge':{
+        on:['click'],
+        gkeys:['pos:tables:merge'],
+        handler:(e,ctx)=>{
+          const t = getTexts(ctx.getState());
+          UI.pushToast(ctx, { title:t.toast.merge_stub, icon:'🔗' });
+        }
+      },
+      'pos.payments.open':{
+        on:['click'],
+        gkeys:['pos:payments:open'],
+        handler:(e,ctx)=>{
+          ctx.setState(s=>({
+            ...s,
+            ui:{
+              ...(s.ui || {}),
+              modals:{ ...(s.ui?.modals || {}), payments:true },
+              paymentDraft:{ amount:'', method: s.data.payments?.activeMethod || 'cash' }
+            }
+          }));
+          ctx.rebuild();
+        }
+      },
+      'pos.payments.close':{
+        on:['click'],
+        gkeys:['pos:payments:close','ui:drawer:close'],
+        handler:(e,ctx)=>{
+          ctx.setState(s=>({
+            ...s,
+            ui:{ ...(s.ui || {}), modals:{ ...(s.ui?.modals || {}), payments:false } }
+          }));
+          ctx.rebuild();
+        }
+      },
+      'pos.payments.method':{
+        on:['click'],
+        gkeys:['pos:payments:method'],
+        handler:(e,ctx)=>{
+          const btn = e.target.closest('[data-method-id]');
+          if(!btn) return;
+          const method = btn.getAttribute('data-method-id');
+          ctx.setState(s=>({
+            ...s,
+            data:{ ...(s.data || {}), payments:{ ...(s.data.payments || {}), activeMethod: method } },
+            ui:{ ...(s.ui || {}), paymentDraft:{ ...(s.ui?.paymentDraft || {}), method } }
+          }));
+          ctx.rebuild();
+        }
+      },
+      'pos.payments.amount':{
+        on:['input','change'],
+        gkeys:['pos:payments:amount'],
+        handler:(e,ctx)=>{
+          const value = e.target.value;
+          ctx.setState(s=>({
+            ...s,
+            ui:{ ...(s.ui || {}), paymentDraft:{ ...(s.ui?.paymentDraft || {}), amount:value } }
+          }));
+          ctx.rebuild();
+        }
+      },
+      'pos.payments.capture':{
+        on:['click'],
+        gkeys:['pos:payments:capture'],
+        handler:(e,ctx)=>{
+          const state = ctx.getState();
+          const t = getTexts(state);
+          const amount = parseFloat(state.ui?.paymentDraft?.amount);
+          if(!amount || amount <= 0){
+            UI.pushToast(ctx, { title:t.toast.amount_required, icon:'⚠️' });
+            return;
+          }
+          const method = state.data.payments.activeMethod || 'cash';
+          ctx.setState(s=>({
+            ...s,
+            data:{
+              ...s.data,
+              payments:{
+                ...(s.data.payments || {}),
+                split:(s.data.payments?.split || []).concat([{ id:`pm-${Date.now()}`, method, amount: round(amount) }])
+              }
+            },
+            ui:{ ...(s.ui || {}), modals:{ ...(s.ui?.modals || {}), payments:false }, paymentDraft:{ amount:'' } }
+          }));
+          ctx.rebuild();
+          UI.pushToast(ctx, { title:t.toast.payment_recorded, icon:'💰' });
+        }
+      },
+      'pos.payments.split':{
+        on:['click'],
+        gkeys:['pos:payments:split'],
+        handler:(e,ctx)=>{
+          ctx.setState(s=>({
+            ...s,
+            ui:{ ...(s.ui || {}), modals:{ ...(s.ui?.modals || {}), payments:true } }
+          }));
+          ctx.rebuild();
+        }
+      },
+      'pos.reports.toggle':{
+        on:['click'],
+        gkeys:['pos:reports:toggle'],
+        handler:(e,ctx)=>{
+          ctx.setState(s=>({
+            ...s,
+            ui:{ ...(s.ui || {}), modals:{ ...(s.ui?.modals || {}), reports: !s.ui?.modals?.reports } }
+          }));
+          ctx.rebuild();
+        }
+      },
+      'pos.indexeddb.sync':{
+        on:['click'],
+        gkeys:['pos:indexeddb:sync'],
+        handler: async (e,ctx)=>{
+          const state = ctx.getState();
+          const t = getTexts(state);
+          if(!posDB.available){
+            UI.pushToast(ctx, { title:t.toast.indexeddb_missing, icon:'⚠️' });
+            return;
+          }
+          try{
+            UI.pushToast(ctx, { title:t.toast.indexeddb_syncing, icon:'🔄' });
+            const orders = await posDB.listOrders();
+            await posDB.markSync();
+            ctx.setState(s=>({
+              ...s,
+              data:{
+                ...s.data,
+                status:{ ...s.data.status, indexeddb:{ state:'online', lastSync: Date.now() } },
+                reports:{ ...(s.data.reports || {}), ordersCount: orders.length }
+              }
+            }));
+            ctx.rebuild();
+            UI.pushToast(ctx, { title:t.toast.sync_complete, icon:'✅' });
+          } catch(error){
+            UI.pushToast(ctx, { title:t.toast.indexeddb_error, message:String(error), icon:'🛑' });
+            ctx.setState(s=>({
+              ...s,
+              data:{
+                ...s.data,
+                status:{ ...s.data.status, indexeddb:{ state:'offline', lastSync: s.data.status?.indexeddb?.lastSync || null } }
+              }
+            }));
+            ctx.rebuild();
+          }
+        }
+      },
+      'pos.kds.connect':{
+        on:['click'],
+        gkeys:['pos:kds:connect'],
+        handler:(e,ctx)=>{
+          kdsBridge.connect(ctx);
+        }
+      },
+      'pos.theme.toggle':{
+        on:['click'],
+        gkeys:['pos:theme:toggle'],
+        handler:(e,ctx)=>{
+          const btn = e.target.closest('[data-theme]');
+          if(!btn) return;
+          const theme = btn.getAttribute('data-theme');
+          ctx.setState(s=>({
+            ...s,
+            env:{ ...(s.env || {}), theme }
+          }));
+          ctx.rebuild();
+          const t = getTexts(ctx.getState());
+          UI.pushToast(ctx, { title:t.toast.theme_switched, icon: theme === 'dark' ? '🌙' : '☀️' });
+        }
+      },
+      'pos.lang.switch':{
+        on:['click'],
+        gkeys:['pos:lang:switch'],
+        handler:(e,ctx)=>{
+          const btn = e.target.closest('[data-lang]');
+          if(!btn) return;
+          const lang = btn.getAttribute('data-lang');
+          ctx.setState(s=>({
+            ...s,
+            env:{ ...(s.env || {}), lang, dir: lang === 'ar' ? 'rtl' : 'ltr' }
+          }));
+          ctx.rebuild();
+          const t = getTexts(ctx.getState());
+          UI.pushToast(ctx, { title:t.toast.lang_switched, icon:'🌐' });
+        }
+      },
+      'pos.session.logout':{
+        on:['click'],
+        gkeys:['pos:session:logout'],
+        handler:(e,ctx)=>{
+          const t = getTexts(ctx.getState());
+          UI.pushToast(ctx, { title:t.toast.logout_stub, icon:'👋' });
+        }
+      }
+    };
+
+    app.setOrders(Object.assign({}, UI.orders, auto.orders, posOrders));
+    app.mount('#app');
+  })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- rebuild the POS shell around a full-screen touch layout with localized menu, segmented order types, and compact item cards
- add header language and theme switches, favorites filtering, payment drawer, and refreshed table/reports overlays
- integrate IndexedDB save/sync flows, WebSocket KDS connector, and rich Mishkah orders to drive live cart, payment, and status updates

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68de467e11c08333959d45a1c5f9ccf8