### PR TITLE
Fix POS viewport layout to keep header and footer visible

### DIFF
--- a/mishkah-ui.js
+++ b/mishkah-ui.js
@@ -48,8 +48,8 @@ def({
   'card/desc':      'text-sm text-[var(--muted-foreground)]',
 
   // bars
-  'toolbar':        'flex items-center justify-between px-4 py-3 border-b border-[var(--border)] bg-[color-mix(in oklab,var(--background) 85%, transparent)] backdrop-blur-sm',
-  'footerbar':      'flex items-center justify-between px-4 py-3 border-t border-[var(--border)] bg-[var(--card)] text-[var(--card-foreground)]',
+  'toolbar':        'flex shrink-0 items-center justify-between px-4 py-3 border-b border-[var(--border)] bg-[color-mix(in oklab,var(--background) 85%, transparent)] backdrop-blur-sm',
+  'footerbar':      'flex shrink-0 items-center justify-between px-4 py-3 border-t border-[var(--border)] bg-[var(--card)] text-[var(--card-foreground)]',
 
   // inputs
   'input':          'flex h-10 w-full rounded-[var(--radius)] border border-[var(--input)] bg-[var(--background)] px-3 py-2 text-sm placeholder:text-[var(--muted-foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)] disabled:opacity-50 disabled:pointer-events-none',
@@ -107,7 +107,7 @@ function withClass(attrs, add){ const a=Object.assign({},attrs||{}); a.class = t
 const UI = {};
 
 UI.AppRoot = ({ shell, overlays }) =>
-  h.Containers.Div({ attrs:{ class: tw`${token('surface')} min-h-screen` }}, [ shell, ...(overlays||[]) ]);
+  h.Containers.Div({ attrs:{ class: tw`${token('surface')} flex h-screen min-h-screen flex-col overflow-hidden` }}, [ shell, ...(overlays||[]) ]);
 
 UI.Toolbar = ({ left=[], right=[] }) =>
   h.Containers.Header({ attrs:{ class: tw`${token('toolbar')}` }}, [

--- a/pos.html
+++ b/pos.html
@@ -6,10 +6,25 @@
   <title>مشكاة — نقطة البيع للمطاعم</title>
   <style>
     :root { color-scheme: light dark; }
-    html, body { height: 100%; margin: 0; overflow: hidden; background: var(--background, #0f1115); }
-    body { font-family: "Tajawal", "Cairo", system-ui, sans-serif; touch-action: manipulation; }
-    #app { height: 100%; }
-    .pos-shell { height: 100%; }
+    html, body {
+      height: 100%;
+      min-height: 100vh;
+      margin: 0;
+      overflow: hidden;
+      background: var(--background, #0f1115);
+    }
+    body {
+      font-family: "Tajawal", "Cairo", system-ui, sans-serif;
+      touch-action: manipulation;
+      display: flex;
+      min-height: 100vh;
+    }
+    #app {
+      flex: 1 1 auto;
+      min-height: 100vh;
+      display: flex;
+    }
+    .pos-shell { flex: 1 1 auto; }
   </style>
   <script src="./mishkah-utils.js"></script>
   <script src="./mishkah.core.js"></script>
@@ -723,7 +738,7 @@
         label: localize(cat.label, lang),
         attrs:{ gkey:'pos:menu:category', 'data-category-id':cat.id }
       }));
-      return D.Containers.Section({ attrs:{ class: tw`flex h-full flex-col gap-3 overflow-hidden` }}, [
+      return D.Containers.Section({ attrs:{ class: tw`flex h-full min-h-0 flex-col gap-3 overflow-hidden` }}, [
         UI.Card({
           variant:'card/soft-1',
           content: D.Containers.Div({ attrs:{ class: tw`flex flex-col gap-3` }}, [
@@ -745,7 +760,7 @@
             UI.ChipGroup({ items: chips, activeId: menu.category })
           ])
         }),
-        D.Containers.Section({ attrs:{ class: tw`${token('scroll-panel')} flex-1 overflow-hidden` }}, [
+        D.Containers.Section({ attrs:{ class: tw`${token('scroll-panel')} flex-1 min-h-0 overflow-hidden` }}, [
           D.Containers.Div({ attrs:{ class: tw`${token('scroll-panel/head')}` }}, [
             D.Text.Strong({}, [t.ui.categories]),
             UI.Button({ attrs:{ gkey:'pos:menu:load-more' }, variant:'ghost', size:'sm' }, [t.ui.load_more])
@@ -913,10 +928,10 @@
         label: `${type.icon} ${localize(type.label, db.env.lang)}`,
         attrs:{ gkey:'pos:order:type', 'data-order-type':type.id }
       }));
-      return D.Containers.Section({ attrs:{ class: tw`flex h-full flex-col gap-3 overflow-hidden` }}, [
+      return D.Containers.Section({ attrs:{ class: tw`flex h-full min-h-0 flex-col gap-3 overflow-hidden` }}, [
         UI.Card({
           variant:'card/soft-1',
-          content: D.Containers.Div({ attrs:{ class: tw`flex h-full flex-col gap-3` }}, [
+          content: D.Containers.Div({ attrs:{ class: tw`flex h-full min-h-0 flex-col gap-3` }}, [
             UI.Segmented({ items: serviceSegments, activeId: order.type }),
             D.Containers.Div({ attrs:{ class: tw`flex flex-wrap items-center justify-between gap-2 text-xs sm:text-sm ${token('muted')}` }}, [
               D.Text.Span({}, [`${t.ui.order_id} ${order.id}`]),
@@ -942,7 +957,7 @@
             ]),
             D.Containers.Div({ attrs:{ class: tw`flex-1 min-h-0` }}, [
               UI.ScrollArea({
-                attrs:{ class: tw`flex h-full flex-1 overflow-auto pr-2` },
+                attrs:{ class: tw`flex h-full min-h-0 flex-1 overflow-auto pr-2` },
                 children:[
                   order.lines && order.lines.length
                     ? UI.List({ children: order.lines.map(line=> OrderLine(db, line)) })
@@ -1562,9 +1577,9 @@
 
     Mishkah.app.setBody(function(db){
       return UI.AppRoot({
-        shell: D.Containers.Div({ attrs:{ class: tw`pos-shell flex h-full flex-col overflow-hidden bg-[var(--background)] text-[var(--foreground)]` }}, [
+        shell: D.Containers.Div({ attrs:{ class: tw`pos-shell flex h-full min-h-0 flex-col overflow-hidden bg-[var(--background)] text-[var(--foreground)]` }}, [
           Header(db),
-          D.Containers.Main({ attrs:{ class: tw`flex-1 grid gap-4 px-4 pb-3 pt-3 lg:grid-cols-[minmax(0,2.4fr)_minmax(0,1fr)] overflow-hidden` }}, [
+          D.Containers.Main({ attrs:{ class: tw`flex-1 min-h-0 grid gap-4 px-4 pb-3 pt-3 lg:grid-cols-[minmax(0,2.4fr)_minmax(0,1fr)] overflow-hidden` }}, [
             MenuColumn(db),
             OrderColumn(db)
           ]),


### PR DESCRIPTION
## Summary
- ensure the POS page root and app container stretch to the full viewport using flexbox so the header and footer stay exposed
- update the UI AppRoot shell to occupy the full screen height and keep internal areas scrollable within the available space

## Testing
- none


------
https://chatgpt.com/codex/tasks/task_e_68df96afc7c88333a20a87c673c33a61