### PR TITLE
Harden scroll restoration across rebuilds

### DIFF
--- a/index.html
+++ b/index.html
@@ -1081,6 +1081,11 @@
           ])
         : null;
 
+      const playItems = [resultCard, boardCard].filter(Boolean);
+      const playSection = playItems.length > 1
+        ? D.Containers.Div({ attrs:{ class: tw`space-y-6` }}, playItems)
+        : boardCard;
+
       const audioNode = (g.musicOn && g.status==='running')
         ? D.Media.Audio({ attrs:{ autoplay:true, loop:true, src:g.audioList[g.audioIdx].url, class: tw`hidden`, key:`bgm-${g.soundStamp||0}` }})
         : null;
@@ -1091,10 +1096,9 @@
 
       return D.Containers.Div({ attrs:{ class: `${tw`relative space-y-6`} game-panel` }}, [
         confettiLayer,
-        resultCard,
         controlCard,
+        playSection,
         infoSection,
-        boardCard,
         audioNode,
         cueAudio
       ].filter(Boolean));
@@ -1190,6 +1194,8 @@
     // هذه هي الأوامر والأفعال التي تحرك الجسد وتغير من حال "إيمانه".
     // كل "order" هو عمل صالح يستجيب لأحداث المستخدم ويُحدّث الحالة.
     // ----------------------------------------------------------------
+    const KEEP_MAIN_SCROLL = { keepScroll:['.main-region'] };
+
     const orders = {
       // Routing
       'route:readmeBase':{ on:['click'], gkeys:['route:readmeBase'], handler:(e,ctx)=>{ const s=ctx.getState(); ctx.setState({...s, data:{...s.data, activeTab:'readmeBase' }}); ctx.rebuild(); }},
@@ -1206,21 +1212,21 @@
       'game:music:toggle':{ on:['change'], gkeys:['game:music:toggle'], handler:(e,ctx)=>{
         const s=ctx.getState(); const g=s.data.game; const on = !!e.target.checked;
         const stamp = on ? Date.now() : g.soundStamp;
-        ctx.setState({...s, data:{...s.data, game:{...g, musicOn:on, soundStamp: stamp }}}); ctx.rebuild();
+        ctx.setState({...s, data:{...s.data, game:{...g, musicOn:on, soundStamp: stamp }}}); ctx.rebuild(KEEP_MAIN_SCROLL);
       }},
       'game:music:select':{ on:['change'], gkeys:['game:music:select'], handler:(e,ctx)=>{
         const s=ctx.getState(); const g=s.data.game; const idx=Math.max(0,parseInt(e.target.value,10)||0);
-        ctx.setState({...s, data:{...s.data, game:{...g, audioIdx: idx, soundStamp: Date.now() }}}); ctx.rebuild();
+        ctx.setState({...s, data:{...s.data, game:{...g, audioIdx: idx, soundStamp: Date.now() }}}); ctx.rebuild(KEEP_MAIN_SCROLL);
       }},
       'game:timer:toggle':{ on:['change'], gkeys:['game:timer:toggle'], handler:(e,ctx)=>{
         const s=ctx.getState(); const g=s.data.game; const on=!!e.target.checked; if(!on && g.intervalId) try{ clearInterval(g.intervalId); }catch(_){ }
         const timeLeft = on ? (g.status==='running' ? (typeof g.timeLeft === 'number' && g.timeLeft>0 ? g.timeLeft : g.timerSec) : g.timerSec) : 0;
-        ctx.setState({...s, data:{...s.data, game:{...g, timerOn:on, timeLeft, intervalId: on ? g.intervalId : null }}}); ctx.rebuild();
+        ctx.setState({...s, data:{...s.data, game:{...g, timerOn:on, timeLeft, intervalId: on ? g.intervalId : null }}}); ctx.rebuild(KEEP_MAIN_SCROLL);
       }},
       'game:timer:value':{ on:['input','change'], gkeys:['game:timer:value'], handler:(e,ctx)=>{
         const s=ctx.getState(); const g=s.data.game; const v=Math.max(5, parseInt(e.target.value,10)||g.timerSec);
         const timeLeft = g.timerOn ? (g.status==='running' ? v : v) : g.timeLeft;
-        ctx.setState({...s, data:{...s.data, game:{...g, timerSec: v, timeLeft }}}); ctx.rebuild();
+        ctx.setState({...s, data:{...s.data, game:{...g, timerSec: v, timeLeft }}}); ctx.rebuild(KEEP_MAIN_SCROLL);
       }},
 
       // Start / New game
@@ -1230,7 +1236,7 @@
         const stamp = Date.now();
         const baseTime = g0.timerOn ? g0.timerSec : 0;
         const g1 = { ...g0, proverb: pv, guessed:{}, triesLeft:g0.triesMax, status:'running', timeLeft: baseTime, intervalId:null, revealSolution:false, soundStamp: stamp, feedback:null };
-        ctx.setState({ ...s0, data:{ ...s0.data, game:g1 } }); ctx.rebuild();
+        ctx.setState({ ...s0, data:{ ...s0.data, game:g1 } }); ctx.rebuild(KEEP_MAIN_SCROLL);
 
         if (g1.timerOn) {
           const iid = setInterval(()=>{
@@ -1252,10 +1258,10 @@
                 feedback = { type:'wrong', stamp: Date.now() };
               }
             }
-            ctx.setState({ ...s, data:{ ...s.data, game:{ ...g, timeLeft, triesLeft, status, feedback, revealSolution: status==='won' ? true : g.revealSolution } }}); ctx.rebuild();
+            ctx.setState({ ...s, data:{ ...s.data, game:{ ...g, timeLeft, triesLeft, status, feedback, revealSolution: status==='won' ? true : g.revealSolution } }}); ctx.rebuild(KEEP_MAIN_SCROLL);
           }, 1000);
           const s1=ctx.getState(); const g2=s1.data.game;
-          ctx.setState({ ...s1, data:{ ...s1.data, game:{ ...g2, intervalId:iid }}}); ctx.rebuild();
+          ctx.setState({ ...s1, data:{ ...s1.data, game:{ ...g2, intervalId:iid }}}); ctx.rebuild(KEEP_MAIN_SCROLL);
         }
       }},
 
@@ -1288,11 +1294,11 @@
           timeLeft,
           revealSolution: status==='won' ? true : g.revealSolution,
           feedback
-        }}}); ctx.rebuild();
+        }}}); ctx.rebuild(KEEP_MAIN_SCROLL);
       }},
       'game:reveal':{ on:['click'], gkeys:['game:reveal'], handler:(e,ctx)=>{
         const s=ctx.getState(); const g=s.data.game; if (!g.proverb) return;
-        ctx.setState({ ...s, data:{ ...s.data, game:{ ...g, revealSolution:true }}}); ctx.rebuild();
+        ctx.setState({ ...s, data:{ ...s.data, game:{ ...g, revealSolution:true }}}); ctx.rebuild(KEEP_MAIN_SCROLL);
       }}
     };
 

--- a/mishkah.core.js
+++ b/mishkah.core.js
@@ -656,6 +656,157 @@
     }
 
     function createContext(){
+      function captureScrollTarget(target){
+        var doc = global && global.document;
+        if (!doc || !target) return null;
+
+        if (typeof target === 'function'){
+          try { target = target(); } catch(_){ return null; }
+          if (!target) return null;
+        }
+
+        var node = null;
+        var selector = null;
+        var isWindow = false;
+
+        if (target === 'window' || target === global || (global && target === global.window)){
+          var scrollNode = doc.scrollingElement || doc.documentElement || doc.body;
+          var winTop = (typeof global.scrollY === 'number') ? global.scrollY : (scrollNode ? scrollNode.scrollTop : 0);
+          var winLeft = (typeof global.scrollX === 'number') ? global.scrollX : (scrollNode ? scrollNode.scrollLeft : 0);
+          return { node: scrollNode, selector: null, top: winTop, left: winLeft, isWindow: true };
+        }
+
+        if (typeof Element !== 'undefined' && target instanceof Element){ node = target; }
+        else if (target && target.nodeType === 1){ node = target; }
+        else if (isObj(target)){
+          if (!node && target.node && typeof Element !== 'undefined' && target.node instanceof Element){ node = target.node; }
+          if (!selector && target.selector!=null){ selector = String(target.selector); }
+          if (!node && typeof target.get === 'function'){
+            try {
+              var got = target.get();
+              if (typeof Element !== 'undefined' && got instanceof Element){ node = got; }
+              else if (got && got.nodeType === 1){ node = got; }
+              else if (!selector && typeof got === 'string'){ selector = got; }
+            } catch(_g){ }
+          }
+        }
+
+        if (!node && typeof target === 'string'){ selector = selector || String(target); }
+
+        if (!node && selector){
+          try { node = doc.querySelector(selector); } catch(_q){ node = null; }
+        } else if (!node && typeof target === 'string'){
+          try { node = doc.querySelector(String(target)); } catch(_s){ node = null; }
+        }
+
+        if (!node) return null;
+
+        if (!selector && node.getAttribute){
+          var pathAttr = node.getAttribute('data-m-path');
+          if (pathAttr){ selector = '[data-m-path="' + String(pathAttr).replace(/\\/g,'\\\\').replace(/"/g,'\\"') + '"]'; }
+          if (!selector){
+            var keyAttr = node.getAttribute('data-m-key');
+            if (keyAttr){ selector = '[data-m-key="' + String(keyAttr).replace(/\\/g,'\\\\').replace(/"/g,'\\"') + '"]'; }
+          }
+        }
+
+        var top = (typeof node.scrollTop === 'number') ? node.scrollTop : 0;
+        var left = (typeof node.scrollLeft === 'number') ? node.scrollLeft : 0;
+        if (node === doc.body || node === doc.documentElement){
+          if (typeof global.scrollY === 'number') top = global.scrollY;
+          if (typeof global.scrollX === 'number') left = global.scrollX;
+        }
+
+        return { node: node, selector: selector, top: top, left: left, isWindow: isWindow };
+      }
+
+      function restoreScrollEntry(entry){
+        if (!entry) return;
+        var doc = global && global.document;
+        if (entry.isWindow){
+          var topWin = entry.top != null ? entry.top : 0;
+          var leftWin = entry.left != null ? entry.left : 0;
+          try {
+            if (typeof global.scrollTo === 'function'){
+              try { global.scrollTo({ top: topWin, left: leftWin, behavior:'instant' }); }
+              catch(_o){ try { global.scrollTo(leftWin, topWin); } catch(_p){} }
+            } else if (doc && doc.scrollingElement){
+              if (entry.top != null) doc.scrollingElement.scrollTop = entry.top;
+              if (entry.left != null) doc.scrollingElement.scrollLeft = entry.left;
+            }
+          } catch(_w){ }
+          return;
+        }
+
+        var nodeRef = entry.node;
+        if (entry.selector && (!nodeRef || !nodeRef.isConnected || nodeRef.parentNode==null)){
+          if (doc){
+            try {
+              var found = doc.querySelector(entry.selector);
+              if (found) nodeRef = entry.node = found;
+            } catch(_r){ }
+          }
+        }
+        if (!nodeRef) return;
+
+        var prevBehavior = null;
+        var behaviorApplied = false;
+        try {
+          if (nodeRef.style && typeof nodeRef.style === 'object'){
+            prevBehavior = nodeRef.style.scrollBehavior;
+            nodeRef.style.scrollBehavior = 'auto';
+            behaviorApplied = true;
+          }
+        } catch(_sb){ behaviorApplied = false; }
+
+        try {
+          if (typeof nodeRef.scrollTo === 'function'){
+            var topVal = entry.top != null ? entry.top : nodeRef.scrollTop;
+            var leftVal = entry.left != null ? entry.left : nodeRef.scrollLeft;
+            try {
+              nodeRef.scrollTo({ top: topVal, left: leftVal, behavior:'instant' });
+            } catch(_cObj){
+              try { nodeRef.scrollTo(leftVal, topVal); } catch(_n){}
+              if (entry.top != null) nodeRef.scrollTop = entry.top;
+              if (entry.left != null) nodeRef.scrollLeft = entry.left;
+            }
+          } else {
+            if (entry.top != null) nodeRef.scrollTop = entry.top;
+            if (entry.left != null) nodeRef.scrollLeft = entry.left;
+          }
+        } catch(_ap){
+          try {
+            if (entry.top != null) nodeRef.scrollTop = entry.top;
+            if (entry.left != null) nodeRef.scrollLeft = entry.left;
+          } catch(_aq){ }
+        } finally {
+          if (behaviorApplied && nodeRef && nodeRef.style){
+            try {
+              if (prevBehavior && prevBehavior.length){ nodeRef.style.scrollBehavior = prevBehavior; }
+              else if (typeof nodeRef.style.removeProperty === 'function'){ nodeRef.style.removeProperty('scroll-behavior'); }
+              else nodeRef.style.scrollBehavior = '';
+            } catch(_be){ }
+          }
+        }
+      }
+
+      function restoreScrollEntries(entries){
+        if (!entries || !entries.length) return;
+        for (var i=0;i<entries.length;i++) restoreScrollEntry(entries[i]);
+        var raf = global && typeof global.requestAnimationFrame === 'function' ? global.requestAnimationFrame : null;
+        if (raf){
+          raf(function(){
+            for (var j=0;j<entries.length;j++) restoreScrollEntry(entries[j]);
+            raf(function(){ for (var k=0;k<entries.length;k++) restoreScrollEntry(entries[k]); });
+          });
+        } else if (global && typeof global.setTimeout === 'function'){
+          global.setTimeout(function(){
+            for (var j2=0;j2<entries.length;j2++) restoreScrollEntry(entries[j2]);
+            global.setTimeout(function(){ for (var k2=0;k2<entries.length;k2++) restoreScrollEntry(entries[k2]); }, 16);
+          }, 0);
+        }
+      }
+
       return {
         root: _$root,
         getState: function(){ return _database; },
@@ -671,6 +822,15 @@
           applyEnv(_database);
           var head = _database && _database.head; if (head) Head.batch(head);
 
+          var keepScrollEntries = [];
+          var keepScrollTargets = toArr(opts && opts.keepScroll);
+          if (keepScrollTargets.length && global && global.document){
+            for (var i=0;i<keepScrollTargets.length;i++){
+              var entry = captureScrollTarget(keepScrollTargets[i]);
+              if (entry) keepScrollEntries.push(entry);
+            }
+          }
+
           var options = { freeze: new Set(toArr(opts && opts.except)), only: new Set(toArr(opts && opts.buildonly)) };
           var self = this;
           M.Devtools.scheduleRebuild(self, function(){
@@ -680,6 +840,7 @@
             _vApp = next;
             try { M.RuleCenter && M.RuleCenter.evaluate && M.RuleCenter.evaluate('afterRender', { rootEl:_$root, db:_database }, _ctx); } catch(eAR){ M.Auditor.warn('W-AFTER','afterRender rules error', {error:String(eAR)}); }
             if (M.Devtools && M.Devtools.auditOrdersKeys) M.Devtools.auditOrdersKeys(_$root, _ordersArr);
+            if (keepScrollEntries.length) restoreScrollEntries(keepScrollEntries);
           });
         },
         batch: function(fn){ if (typeof fn==='function') fn(this); this.rebuild(); }


### PR DESCRIPTION
## Summary
- expand keepScroll handling to accept functions, selectors, or window targets when capturing scroll containers
- reapply saved scroll positions immediately and on subsequent animation frames while temporarily disabling smooth scrolling
- reuse the enhanced helper to resolve replaced nodes before restoring offsets so rebuilds keep the play area anchored

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0f67d3c8c8333a96000cc85da327b