### PR TITLE
Improve shift PIN flow and summary reporting

### DIFF
--- a/pos.html
+++ b/pos.html
@@ -85,6 +85,7 @@
         en: type.type_name?.en || type.id
       }
     }));
+    const ORDER_TYPE_IDS = new Set(ORDER_TYPES.map(type=> type.id));
 
     const rawPaymentMethods = Array.isArray(MOCK.payment_methods) && MOCK.payment_methods.length
       ? MOCK.payment_methods
@@ -103,8 +104,11 @@
     }));
 
     const SHIFT_SETTINGS = typeof MOCK.shift_settings === 'object' && MOCK.shift_settings ? MOCK.shift_settings : {};
-    const SHIFT_PIN_VALUE = typeof SHIFT_SETTINGS.pin === 'string' ? SHIFT_SETTINGS.pin : (typeof SHIFT_SETTINGS.default_pin === 'string' ? SHIFT_SETTINGS.default_pin : '0000');
-    const SHIFT_PIN_LENGTH = Number(SHIFT_SETTINGS.pin_length || SHIFT_SETTINGS.pinLength || (SHIFT_PIN_VALUE ? SHIFT_PIN_VALUE.length : 4)) || 4;
+    const SHIFT_PIN_FALLBACK = typeof SHIFT_SETTINGS.pin === 'string'
+      ? SHIFT_SETTINGS.pin
+      : (typeof SHIFT_SETTINGS.default_pin === 'string' ? SHIFT_SETTINGS.default_pin : '');
+    let SHIFT_PIN_LENGTH = Number(SHIFT_SETTINGS.pin_length || SHIFT_SETTINGS.pinLength || (SHIFT_PIN_FALLBACK ? SHIFT_PIN_FALLBACK.length : 0)) || 0;
+    if(!SHIFT_PIN_LENGTH || SHIFT_PIN_LENGTH < 4) SHIFT_PIN_LENGTH = 4;
     const SHIFT_OPEN_FLOAT_DEFAULT = Number(SHIFT_SETTINGS.opening_float ?? SHIFT_SETTINGS.openingFloat ?? 0);
 
     const TEXTS = {
@@ -387,6 +391,137 @@
         discount: round(discount),
         deliveryFee: round(deliveryFee),
         due: round(due)
+      };
+    }
+
+    function normalizeOrderTypeId(value){
+      if(!value) return 'dine_in';
+      const normalized = String(value).trim().toLowerCase().replace(/[^a-z0-9]+/g, '_');
+      return ORDER_TYPE_IDS.has(normalized) ? normalized : normalized || 'dine_in';
+    }
+
+    function summarizeShiftOrders(history, shift){
+      if(!shift) return { totalsByType:{}, paymentsByMethod:{}, totalSales:0, orders:[], ordersCount:0, countsByType:{} };
+      const shiftId = shift.id;
+      const historyList = Array.isArray(history) ? history : [];
+      const orders = [];
+      const totalsAccumulator = {};
+      const paymentsAccumulator = {};
+      const countsAccumulator = {};
+      if(shiftId){
+        historyList.forEach(order=>{
+          if(!order || order.shiftId !== shiftId) return;
+          const total = round(order?.totals?.due || 0);
+          const typeKey = normalizeOrderTypeId(order?.type || order?.header?.type_id || 'dine_in');
+          totalsAccumulator[typeKey] = round((totalsAccumulator[typeKey] || 0) + total);
+          countsAccumulator[typeKey] = (countsAccumulator[typeKey] || 0) + 1;
+          const payments = Array.isArray(order?.payments) ? order.payments : [];
+          payments.forEach(payment=>{
+            if(!payment) return;
+            const methodKey = String(payment.method || payment.id || 'cash');
+            const amount = round(payment.amount || 0);
+            paymentsAccumulator[methodKey] = round((paymentsAccumulator[methodKey] || 0) + amount);
+          });
+          orders.push({
+            id: order.id,
+            total,
+            savedAt: order.savedAt || order.updatedAt || order.createdAt || Date.now(),
+            type: typeKey
+          });
+        });
+      }
+      if(!orders.length && Array.isArray(shift.orders) && shift.orders.length){
+        shift.orders.forEach((entry, idx)=>{
+          if(!entry) return;
+          if(typeof entry === 'string'){
+            const typeKey = 'dine_in';
+            countsAccumulator[typeKey] = (countsAccumulator[typeKey] || 0) + 1;
+            orders.push({
+              id: entry,
+              total: 0,
+              savedAt: shift.closedAt || shift.openedAt || Date.now(),
+              type: typeKey
+            });
+          } else {
+            const typeKey = normalizeOrderTypeId(entry.type || entry.orderType || entry.type_id || 'dine_in');
+            const total = round(entry.total || entry.amount || 0);
+            totalsAccumulator[typeKey] = round((totalsAccumulator[typeKey] || 0) + total);
+            countsAccumulator[typeKey] = (countsAccumulator[typeKey] || 0) + 1;
+            orders.push({
+              id: entry.id || entry.orderId || `order-${idx+1}`,
+              total,
+              savedAt: entry.savedAt || entry.updatedAt || shift.closedAt || shift.openedAt || Date.now(),
+              type: typeKey
+            });
+          }
+        });
+      }
+      const totalsKeys = new Set([
+        ...Object.keys(shift.totalsByType || {}),
+        ...Object.keys(totalsAccumulator)
+      ]);
+      const totalsByType = {};
+      if(totalsKeys.size === 0){
+        ORDER_TYPES.forEach(type=>{ totalsByType[type.id] = 0; });
+      } else {
+        totalsKeys.forEach(key=>{
+          const typeKey = normalizeOrderTypeId(key);
+          const computed = totalsAccumulator[typeKey];
+          const fallback = shift.totalsByType?.[typeKey];
+          if(computed != null){
+            totalsByType[typeKey] = round(computed);
+          } else if(fallback != null){
+            totalsByType[typeKey] = round(fallback);
+          }
+        });
+      }
+      const paymentKeys = new Set([
+        ...Object.keys(shift.paymentsByMethod || {}),
+        ...Object.keys(paymentsAccumulator)
+      ]);
+      const paymentsByMethod = {};
+      paymentKeys.forEach(key=>{
+        const computed = paymentsAccumulator[key];
+        const fallback = shift.paymentsByMethod?.[key];
+        if(computed != null){
+          paymentsByMethod[key] = round(computed);
+        } else if(fallback != null){
+          paymentsByMethod[key] = round(fallback);
+        }
+      });
+      const countKeys = new Set([
+        ...Object.keys(shift.countsByType || {}),
+        ...Object.keys(countsAccumulator)
+      ]);
+      const countsByType = {};
+      countKeys.forEach(key=>{
+        const typeKey = normalizeOrderTypeId(key);
+        if(countsAccumulator[typeKey] != null){
+          countsByType[typeKey] = countsAccumulator[typeKey];
+        } else if(shift.countsByType && shift.countsByType[typeKey] != null){
+          countsByType[typeKey] = shift.countsByType[typeKey];
+        }
+      });
+      const totalSales = orders.length
+        ? round(orders.reduce((sum, entry)=> sum + (Number(entry.total)||0), 0))
+        : round(shift.totalSales || 0);
+      const ordersCount = orders.length
+        ? orders.length
+        : (typeof shift.ordersCount === 'number'
+            ? shift.ordersCount
+            : (Array.isArray(shift.orders) ? shift.orders.length : 0));
+      const ordersList = orders.length
+        ? orders
+        : (Array.isArray(shift.orders)
+            ? shift.orders.map(entry=> typeof entry === 'object' ? { ...entry } : { id: entry, total: 0, savedAt: shift.closedAt || shift.openedAt || Date.now(), type:'dine_in' })
+            : []);
+      return {
+        totalsByType,
+        paymentsByMethod,
+        totalSales,
+        orders: ordersList,
+        ordersCount,
+        countsByType
       };
     }
 
@@ -1335,8 +1470,30 @@
       at: evt.at ? new Date(evt.at).getTime() : Date.now(),
       meta: evt.meta || {}
     })) : [];
-    const employees = MOCK.employees || [];
-    const cashier = employees[0] || { full_name:'أحمد محمود', role:'cashier' };
+    const rawEmployees = Array.isArray(MOCK.employees) ? MOCK.employees : [];
+    const employees = rawEmployees.map(emp=>{
+      const pinSource = emp.pin_code ?? emp.pin ?? emp.pinCode ?? emp.passcode ?? '';
+      const pin = typeof pinSource === 'number' ? String(pinSource).padStart(SHIFT_PIN_LENGTH, '0') : String(pinSource || '').trim();
+      return {
+        id: emp.id || emp.employee_id || `emp-${Math.random().toString(36).slice(2,8)}`,
+        name: emp.full_name || emp.name || emp.display_name || emp.username || 'موظف',
+        role: emp.role || 'staff',
+        pin: pin.replace(/\D/g,''),
+        allowedDiscountRate: typeof emp.allowed_discount_rate === 'number'
+          ? emp.allowed_discount_rate
+          : (typeof emp.allowedDiscountRate === 'number' ? emp.allowedDiscountRate : 0)
+      };
+    }).filter(emp=> emp.pin && emp.pin.length);
+    const maxEmployeePinLength = employees.reduce((max, emp)=> Math.max(max, emp.pin.length), 0);
+    if(maxEmployeePinLength) SHIFT_PIN_LENGTH = Math.max(SHIFT_PIN_LENGTH, maxEmployeePinLength);
+    const defaultCashier = employees.find(emp=> emp.role === 'cashier') || employees[0] || {
+      id:'cashier-guest',
+      name:'أحمد محمود',
+      role:'cashier',
+      pin: (SHIFT_PIN_FALLBACK || '0000').replace(/\D/g,''),
+      allowedDiscountRate:0
+    };
+    const cashier = defaultCashier;
 
     function generateOrderId(){
       return 'ORD-' + Date.now().toString(36).toUpperCase();
@@ -1351,8 +1508,10 @@
         settings,
         currency:{ code: currencyCode, symbols: currencySymbols, display: currencyDisplayMode },
         user:{
-          name: cashier.full_name || 'أحمد محمود',
+          id: cashier.id || 'cashier-guest',
+          name: cashier.name || cashier.full_name || 'أحمد محمود',
           role: cashier.role || 'cashier',
+          allowedDiscountRate: typeof cashier.allowedDiscountRate === 'number' ? cashier.allowedDiscountRate : 0,
           shift:'—',
           shiftNo:'#103'
         },
@@ -1360,6 +1519,7 @@
           indexeddb:{ state: posDB.available ? 'idle' : 'offline', lastSync: null },
           kds:{ state:'idle', endpoint:'wss://signal.mas.com.eg/signaldata?id=96nnVOIawRs7Wo_XpAFM0Q' }
         },
+        employees,
         menu:{
           search:'',
           category:'all',
@@ -1447,7 +1607,7 @@
         shift:{
           current:null,
           history: SHIFT_HISTORY_SEED,
-          config:{ pin: SHIFT_PIN_VALUE, pinLength: SHIFT_PIN_LENGTH, openingFloat: SHIFT_OPEN_FLOAT_DEFAULT }
+          config:{ pinLength: SHIFT_PIN_LENGTH, openingFloat: SHIFT_OPEN_FLOAT_DEFAULT }
         }
       },
       ui:{
@@ -2774,17 +2934,22 @@
       if(!shiftUI.showPin) return null;
       const t = getTexts(db);
       const openingFloat = shiftUI.openingFloat ?? db.data.shift?.config?.openingFloat ?? SHIFT_OPEN_FLOAT_DEFAULT;
+      const pinLength = db.data.shift?.config?.pinLength || SHIFT_PIN_LENGTH;
+      const pinPlaceholder = '•'.repeat(Math.max(pinLength || 0, 4));
       return UI.Modal({
         open:true,
         size:'sm',
+        closeGkey:'pos:shift:pin:cancel',
         title:t.ui.shift_open,
         description:t.ui.shift_open_prompt,
         content: D.Containers.Div({ attrs:{ class: tw`space-y-4` }}, [
           UI.NumpadDecimal({
             value: shiftUI.pin || '',
-            placeholder:'••••',
+            placeholder: pinPlaceholder,
             gkey:'pos:shift:pin',
             allowDecimal:false,
+            masked:true,
+            maskLength: pinLength,
             confirmLabel:t.ui.shift_open,
             confirmAttrs:{ gkey:'pos:shift:pin:confirm', variant:'solid', size:'sm', class: tw`w-full` }
           }),
@@ -2826,11 +2991,14 @@
         });
       }
       const lang = db.env.lang;
-      const dineInTotal = round(shift.totalsByType?.dine_in || 0);
-      const takeawayTotal = round(shift.totalsByType?.takeaway || 0);
-      const deliveryTotal = round(shift.totalsByType?.delivery || 0);
-      const totalSales = shift.totalSales != null ? round(shift.totalSales) : round(dineInTotal + takeawayTotal + deliveryTotal);
-      const paymentsByMethod = shift.paymentsByMethod || {};
+      const report = summarizeShiftOrders(db.data.ordersHistory, shift);
+      const totalsByType = report.totalsByType || {};
+      const paymentsByMethod = report.paymentsByMethod || {};
+      const countsByType = report.countsByType || {};
+      const dineInTotal = round(totalsByType.dine_in || 0);
+      const takeawayTotal = round(totalsByType.takeaway || 0);
+      const deliveryTotal = round(totalsByType.delivery || 0);
+      const totalSales = report.totalSales != null ? round(report.totalSales) : round(dineInTotal + takeawayTotal + deliveryTotal);
       const paymentMethods = Array.isArray(db.data.payments?.methods) && db.data.payments.methods.length ? db.data.payments.methods : PAYMENT_METHODS;
       const paymentRows = paymentMethods.map(method=>{
         const amount = round(paymentsByMethod[method.id] || 0);
@@ -2850,7 +3018,7 @@
       const openingFloat = round(shift.openingFloat || 0);
       const cashCollected = round(paymentsByMethod.cash || 0);
       const closingCash = shift.closingCash != null ? round(shift.closingCash) : round(openingFloat + cashCollected);
-      const ordersCount = Array.isArray(shift.orders) ? shift.orders.length : 0;
+      const ordersCount = report.ordersCount != null ? report.ordersCount : (Array.isArray(shift.orders) ? shift.orders.length : 0);
       const openedLabel = shift.openedAt ? formatDateTime(shift.openedAt, lang, { day:'2-digit', month:'short', hour:'2-digit', minute:'2-digit' }) : '—';
       const closedLabel = shift.closedAt ? formatDateTime(shift.closedAt, lang, { day:'2-digit', month:'short', hour:'2-digit', minute:'2-digit' }) : '—';
       const chipsSection = (()=>{
@@ -2869,13 +3037,36 @@
           UI.ChipGroup({ items, activeId: shift.id })
         ]);
       })();
+      const renderTypeRow = (typeId, labelText)=>{
+        const amount = round(totalsByType[typeId] || 0);
+        const count = countsByType[typeId] || 0;
+        return UI.HStack({ attrs:{ class: tw`${token('split')} text-sm` }}, [
+          D.Containers.Div({ attrs:{ class: tw`flex items-center gap-2` }}, [
+            D.Text.Span({}, [labelText]),
+            count ? UI.Badge({ text:String(count), variant:'badge/ghost', attrs:{ class: tw`text-[0.65rem]` } }) : null
+          ].filter(Boolean)),
+          UI.PriceText({ amount, currency:getCurrency(db), locale:getLocale(db) })
+        ]);
+      };
+      const baseTypeRows = [
+        renderTypeRow('dine_in', t.ui.shift_total_dine_in),
+        renderTypeRow('takeaway', t.ui.shift_total_takeaway),
+        renderTypeRow('delivery', t.ui.shift_total_delivery)
+      ];
+      const extraTypeRows = Object.keys(totalsByType)
+        .filter(key=> !['dine_in','takeaway','delivery'].includes(key))
+        .sort()
+        .map(typeId=>{
+          const config = ORDER_TYPES.find(type=> type.id === typeId);
+          const label = config ? localize(config.label, lang) : typeId;
+          return renderTypeRow(typeId, label);
+        });
       const totalsCard = UI.Card({
         variant:'card/soft-1',
         title:t.ui.shift_total_sales,
         content: D.Containers.Div({ attrs:{ class: tw`space-y-2` }}, [
-          UI.HStack({ attrs:{ class: tw`${token('split')} text-sm` }}, [D.Text.Span({}, [t.ui.shift_total_dine_in]), UI.PriceText({ amount:dineInTotal, currency:getCurrency(db), locale:getLocale(db) })]),
-          UI.HStack({ attrs:{ class: tw`${token('split')} text-sm` }}, [D.Text.Span({}, [t.ui.shift_total_takeaway]), UI.PriceText({ amount:takeawayTotal, currency:getCurrency(db), locale:getLocale(db) })]),
-          UI.HStack({ attrs:{ class: tw`${token('split')} text-sm` }}, [D.Text.Span({}, [t.ui.shift_total_delivery]), UI.PriceText({ amount:deliveryTotal, currency:getCurrency(db), locale:getLocale(db) })]),
+          ...baseTypeRows,
+          ...extraTypeRows,
           UI.Divider(),
           UI.HStack({ attrs:{ class: tw`${token('split')} text-base font-semibold` }}, [D.Text.Span({}, [t.ui.shift_total_sales]), UI.PriceText({ amount:totalSales, currency:getCurrency(db), locale:getLocale(db) })])
         ])
@@ -2899,6 +3090,7 @@
         variant:'card/soft-2',
         content: D.Containers.Div({ attrs:{ class: tw`space-y-2 text-xs ${token('muted')}` }}, [
           D.Text.Span({}, [`${t.ui.shift}: ${shift.id}`]),
+          D.Text.Span({}, [`${t.ui.cashier}: ${shift.cashierName || '—'}`]),
           D.Text.Span({}, [`${t.ui.shift_orders_count}: ${ordersCount}`]),
           D.Text.Span({}, [`${openedLabel} → ${closedLabel}`])
         ])
@@ -2917,6 +3109,7 @@
       return UI.Modal({
         open:true,
         size:'lg',
+        closeGkey:'pos:shift:summary:close',
         title:t.ui.shift_summary,
         description:viewingCurrent ? t.ui.shift_current : t.ui.shift_history,
         content,
@@ -3512,28 +3705,16 @@
               }
               let nextShift = data.shift?.current ? { ...data.shift.current } : null;
               if(nextShift){
-                const totalsByType = { ...(nextShift.totalsByType || {}) };
-                const typeKey = order.type || 'dine_in';
-                totalsByType[typeKey] = round((totalsByType[typeKey] || 0) + (orderPayload.totals?.due || 0));
-                const paymentsByMethod = { ...(nextShift.paymentsByMethod || {}) };
-                orderPayload.payments.forEach(payment=>{
-                  paymentsByMethod[payment.method] = round((paymentsByMethod[payment.method] || 0) + payment.amount);
-                });
-                const existingShiftOrderIndex = Array.isArray(nextShift.orders) ? nextShift.orders.findIndex(entry=> entry.id === orderPayload.id) : -1;
-                let shiftOrders = Array.isArray(nextShift.orders) ? nextShift.orders.slice() : [];
-                const shiftOrderEntry = { id: orderPayload.id, total: orderPayload.totals?.due || 0, savedAt: orderPayload.savedAt };
-                if(existingShiftOrderIndex >= 0){
-                  shiftOrders[existingShiftOrderIndex] = shiftOrderEntry;
-                } else {
-                  shiftOrders = shiftOrders.concat([shiftOrderEntry]);
-                }
+                const summary = summarizeShiftOrders(history, { ...nextShift, orders: Array.isArray(nextShift.orders) ? nextShift.orders.slice() : [] });
                 nextShift = {
                   ...nextShift,
-                  totalsByType,
-                  paymentsByMethod,
-                  totalSales: round(Object.values(totalsByType).reduce((sum,val)=> sum + (Number(val)||0), 0)),
-                  orders: shiftOrders,
-                  closingCash: round((nextShift.openingFloat || 0) + (paymentsByMethod.cash || 0))
+                  totalsByType: summary.totalsByType,
+                  paymentsByMethod: summary.paymentsByMethod,
+                  totalSales: summary.totalSales,
+                  orders: summary.orders,
+                  countsByType: summary.countsByType,
+                  ordersCount: summary.ordersCount,
+                  closingCash: round((nextShift.openingFloat || 0) + (summary.paymentsByMethod.cash || 0))
                 };
               }
               return {
@@ -3594,7 +3775,10 @@
         gkeys:['pos:shift:pin'],
         handler:(e,ctx)=>{
           const raw = e.target.value || '';
-          const value = raw.replace(/\D/g,'').slice(0, SHIFT_PIN_LENGTH);
+          const state = ctx.getState();
+          const maxLength = state.data.shift?.config?.pinLength || SHIFT_PIN_LENGTH;
+          const digitsOnly = raw.replace(/\D/g,'');
+          const value = maxLength ? digitsOnly.slice(0, maxLength) : digitsOnly;
           ctx.setState(s=>({
             ...s,
             ui:{ ...(s.ui || {}), shift:{ ...(s.ui?.shift || {}), pin:value } }
@@ -3620,27 +3804,40 @@
         handler:(e,ctx)=>{
           const state = ctx.getState();
           const t = getTexts(state);
-          const pinValue = String(state.ui?.shift?.pin || '').trim();
           const config = state.data.shift?.config || {};
-          const expectedPin = config.pin || SHIFT_PIN_VALUE;
-          const pinLength = config.pinLength || SHIFT_PIN_LENGTH;
-          if(!pinValue || pinValue.length !== pinLength || pinValue !== expectedPin){
+          const rawPin = String(state.ui?.shift?.pin || '').trim();
+          const sanitizedPin = rawPin.replace(/\D/g,'');
+          if(!sanitizedPin){
+            UI.pushToast(ctx, { title:t.toast.shift_pin_invalid, icon:'⚠️' });
+            return;
+          }
+          const employees = Array.isArray(state.data.employees) ? state.data.employees : [];
+          const matchedEmployee = employees.find(emp=> emp.pin === sanitizedPin);
+          if(!matchedEmployee){
             UI.pushToast(ctx, { title:t.toast.shift_pin_invalid, icon:'⚠️' });
             return;
           }
           const now = Date.now();
           const openingFloat = Number(state.ui?.shift?.openingFloat ?? config.openingFloat ?? 0);
-          const user = state.data.user || {};
+          const totalsTemplate = ORDER_TYPES.reduce((acc,type)=>{ acc[type.id] = 0; return acc; }, {});
+          const paymentsTemplate = (state.data.payments?.methods || PAYMENT_METHODS).reduce((acc, method)=>{
+            acc[method.id] = 0;
+            return acc;
+          }, {});
+          const newShiftId = `SHIFT-${now.toString(36).toUpperCase()}`;
           const newShift = {
-            id:`SHIFT-${now.toString(36).toUpperCase()}`,
+            id:newShiftId,
             openedAt: now,
             openingFloat: round(openingFloat),
-            totalsByType:{ dine_in:0, takeaway:0, delivery:0 },
-            paymentsByMethod:{},
+            totalsByType: totalsTemplate,
+            paymentsByMethod: paymentsTemplate,
             totalSales:0,
             orders:[],
-            cashierId: user.id || user.role || 'cashier',
-            cashierName: user.name || '',
+            countsByType:{},
+            ordersCount:0,
+            cashierId: matchedEmployee.id,
+            cashierName: matchedEmployee.name,
+            cashierRole: matchedEmployee.role,
             status:'open',
             closingCash:null
           };
@@ -3648,7 +3845,14 @@
             ...s,
             data:{
               ...s.data,
-              user:{ ...(s.data.user || {}), shift:newShift.id },
+              user:{
+                ...(s.data.user || {}),
+                id: matchedEmployee.id,
+                name: matchedEmployee.name,
+                role: matchedEmployee.role,
+                allowedDiscountRate: matchedEmployee.allowedDiscountRate ?? s.data.user?.allowedDiscountRate,
+                shift:newShift.id
+              },
               order:{ ...(s.data.order || {}), shiftId:newShift.id },
               shift:{ ...(s.data.shift || {}), current:newShift }
             },
@@ -3724,14 +3928,17 @@
             ctx.rebuild();
             return;
           }
-          const paymentsByMethod = currentShift.paymentsByMethod || {};
+          const summary = summarizeShiftOrders(state.data.ordersHistory, currentShift);
+          const paymentsByMethod = summary.paymentsByMethod || {};
           const closingCash = currentShift.closingCash != null ? round(currentShift.closingCash) : round((currentShift.openingFloat || 0) + (paymentsByMethod.cash || 0));
           const closedShift = {
             ...currentShift,
-            totalsByType:{ ...(currentShift.totalsByType || {}) },
-            paymentsByMethod:{ ...paymentsByMethod },
-            orders: Array.isArray(currentShift.orders) ? currentShift.orders.slice() : [],
-            totalSales: round(currentShift.totalSales || 0),
+            totalsByType: summary.totalsByType,
+            paymentsByMethod,
+            orders: summary.orders,
+            countsByType: summary.countsByType,
+            ordersCount: summary.ordersCount,
+            totalSales: summary.totalSales,
             closingCash,
             closedAt: Date.now(),
             status:'closed'
@@ -3741,6 +3948,7 @@
             data:{
               ...s.data,
               user:{ ...(s.data.user || {}), shift:'—' },
+              order:{ ...(s.data.order || {}), shiftId:null },
               shift:{
                 ...(s.data.shift || {}),
                 current:null,


### PR DESCRIPTION
## Summary
- restyle the shared numpad component with larger animated keys, optional masking, and working close wiring for modals
- validate shift PINs against employee records while masking input, updating active cashier metadata, and resetting state when shifts close
- recompute shift summaries from order history to surface accurate dine-in/takeaway/delivery totals, dynamic payment breakdowns, and cashier context

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e135c530c88333a5d7be3c8fce365a