### PR TITLE
Improve dashboard charts and mobile template shell

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <title>لوحة تحكم النمو — عرض قالب مشكاة</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <script src="./mishkah-utils.js"></script>
+  <script src="./mishkah.core.js"></script>
+  <script src="./mishkah-ui.js"></script>
+  <script src="./mishkah.templates.js"></script>
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    const { Chart } = Mishkah.UI;
+
+    const dashboardCopy = {
+      brand: {
+        name: 'مركز نمو التجارة',
+        subtitle: 'مؤشرات الأداء الأسبوعية للمتاجر الإلكترونية',
+        initials: 'TG'
+      },
+      filters: {
+        activeRange: '7d',
+        searchPlaceholder: 'ابحث عن منتج أو قناة تسويق',
+        user: 'ريم حكيم',
+        ranges: [
+          { id: '24h', label: 'آخر ٢٤ ساعة' },
+          { id: '7d', label: 'آخر ٧ أيام' },
+          { id: '30d', label: 'آخر ٣٠ يوم' },
+          { id: 'ytd', label: 'منذ بداية العام' }
+        ],
+        primaryAction: { label: 'تصدير CSV', gkey: 'dashboard:export' }
+      },
+      stats: [
+        { id: 'gmv', title: 'قيمة المبيعات', value: '482,300 ر.س', meta: '+18% عن الأسبوع الماضي' },
+        { id: 'orders', title: 'عدد الطلبات', value: '8,640', meta: '+6% نمو' },
+        { id: 'aov', title: 'متوسط الطلب', value: '55.8 ر.س', meta: '+3.1 ر.س' },
+        { id: 'repeat', title: 'نسبة تكرار الشراء', value: '42%', meta: '+5 نقاط' }
+      ],
+      charts: {
+        performance: {
+          title: 'التدفق اليومي للمبيعات والتحويلات',
+          subtitle: 'قياس نمو المتاجر المتصلة بمنصة مشكاة',
+          height: 320,
+          data: {
+            labels: ['الأحد', 'الإثنين', 'الثلاثاء', 'الأربعاء', 'الخميس', 'الجمعة', 'السبت'],
+            datasets: [
+              {
+                label: 'المبيعات (آلاف ر.س)',
+                data: [58, 62, 64, 71, 78, 86, 92],
+                fill: true,
+                backgroundColor: 'rgba(14,165,233,0.18)',
+                borderColor: 'rgba(14,165,233,1)',
+                pointBackgroundColor: 'rgba(14,165,233,1)'
+              },
+              {
+                label: 'التحويلات (%)',
+                data: [3.1, 3.3, 3.4, 3.6, 3.8, 4.1, 4.3],
+                yAxisID: 'percentage',
+                borderColor: 'rgba(251,191,36,1)',
+                backgroundColor: 'rgba(251,191,36,0.28)',
+                pointBackgroundColor: 'rgba(251,191,36,1)',
+                fill: false
+              }
+            ]
+          },
+          options: {
+            scales: {
+              y: { suggestedMax: 100 },
+              percentage: {
+                position: 'right',
+                suggestedMax: 5,
+                ticks: { callback: Chart.formatters.percent(1) }
+              }
+            },
+            plugins: { legend: { position: 'bottom' } }
+          }
+        },
+        conversion: {
+          title: 'معدل التحويل حسب القناة',
+          subtitle: 'حملات هذا الأسبوع مقارنة بالماضي',
+          height: 220,
+          data: {
+            labels: ['إعلانات بحث', 'وسائل التواصل', 'الشركاء', 'النشرات البريدية'],
+            datasets: [
+              {
+                label: 'معدل التحويل',
+                data: [5.4, 3.8, 4.7, 6.1],
+                backgroundColor: [
+                  'rgba(59,130,246,0.85)',
+                  'rgba(129,140,248,0.85)',
+                  'rgba(16,185,129,0.85)',
+                  'rgba(251,191,36,0.85)'
+                ],
+                borderRadius: 16
+              }
+            ]
+          },
+          options: {
+            plugins: { legend: { display: false } },
+            scales: {
+              y: {
+                beginAtZero: true,
+                ticks: { callback: Chart.formatters.percent(1) }
+              }
+            }
+          }
+        },
+        breakdown: {
+          title: 'الأجهزة الأكثر استخدامًا',
+          subtitle: 'نسبة الجلسات عبر القنوات المختلفة',
+          height: 220,
+          data: {
+            labels: ['الهاتف', 'الحاسوب', 'الأجهزة اللوحية'],
+            datasets: [
+              {
+                data: [61, 29, 10],
+                backgroundColor: ['#6366F1', '#10B981', '#F59E0B'],
+                borderWidth: 0
+              }
+            ]
+          },
+          options: {
+            plugins: { legend: { position: 'right' } }
+          }
+        }
+      },
+      table: {
+        title: 'أداء المتاجر المتقدمة',
+        subtitle: 'أفضل ٥ متاجر من حيث النمو',
+        columns: [
+          { key: 'store', label: 'المتجر' },
+          { key: 'sessions', label: 'الزيارات' },
+          { key: 'orders', label: 'الطلبات' },
+          { key: 'rate', label: 'التحويل' }
+        ],
+        rows: [
+          { store: 'نور للعطور', sessions: '24,500', orders: '1,560', rate: '6.4%' },
+          { store: 'مطبخ المذاق', sessions: '17,820', orders: '980', rate: '5.5%' },
+          { store: 'زهرة الرياض', sessions: '14,230', orders: '860', rate: '6.0%' },
+          { store: 'متجر الألعاب الذكية', sessions: '13,940', orders: '720', rate: '5.2%' },
+          { store: 'أزياء نوفا', sessions: '11,310', orders: '610', rate: '5.4%' }
+        ],
+        action: { label: 'عرض جميع المتاجر', gkey: 'dashboard:table:action' }
+      },
+      activity: {
+        title: 'مهام الفريق هذا الأسبوع',
+        subtitle: 'أولويات العمليات والتسويق',
+        items: [
+          { id: 'campaign', icon: '🚀', title: 'إطلاق حملة الصيف', status: 'جاهزة للجدولة', due: 'اليوم' },
+          { id: 'inventory', icon: '📦', title: 'مراجعة المخزون', status: 'قيد التنفيذ', due: 'غدًا' },
+          { id: 'support', icon: '💬', title: 'متابعة تقييمات العملاء', status: 'بحاجة لمراجعة', due: 'الخميس' }
+        ]
+      }
+    };
+
+    Mishkah.Templates.dashboard.create({
+      mount: '#app',
+      theme: 'light',
+      copy: dashboardCopy
+    });
+
+    window.addEventListener('mishkah:template', (event) => {
+      const detail = event.detail || {};
+      const { type, payload } = detail;
+      if (!type) return;
+      if (type === 'dashboard:export') {
+        window.alert('📊 تم تجهيز ملف CSV للتنزيل.');
+      } else if (type === 'dashboard:filters:range') {
+        console.info('🔁 تم تغيير نطاق الوقت:', payload);
+      } else if (type === 'dashboard:table:action') {
+        console.info('📈 عرض المتاجر المتقدمة');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/mishkah-ui.js
+++ b/mishkah-ui.js
@@ -121,6 +121,401 @@ function withClass(attrs, add){ const a=Object.assign({},attrs||{}); a.class = t
 /* ===================== Components ===================== */
 const UI = {};
 
+/* ===================== Chart.js Bridge & Components ===================== */
+const ChartBridge = (() => {
+  const globalObj = typeof window !== 'undefined' ? window : (typeof global !== 'undefined' ? global : {});
+  const parseSafe = U.JSON && typeof U.JSON.parseSafe === 'function' ? U.JSON.parseSafe : (value => {
+    try { return JSON.parse(value); } catch (_err) { return null; }
+  });
+  const clone = U.JSON && typeof U.JSON.clone === 'function' ? U.JSON.clone : (value => {
+    try { return JSON.parse(JSON.stringify(value)); } catch (_err) { return null; }
+  });
+  const stableStringify = U.JSON && typeof U.JSON.stableStringify === 'function'
+    ? U.JSON.stableStringify
+    : (value => {
+        try { return JSON.stringify(value); } catch (_err) { return ''; }
+      });
+  const deepMerge = U.Data && typeof U.Data.deepMerge === 'function'
+    ? U.Data.deepMerge
+    : ((target, source) => {
+        const base = Object.assign({}, target || {});
+        if (!source || typeof source !== 'object') return base;
+        Object.keys(source).forEach((key) => {
+          const next = source[key];
+          if (next && typeof next === 'object' && !Array.isArray(next)) {
+            base[key] = deepMerge(base[key], next);
+          } else {
+            base[key] = next;
+          }
+        });
+        return base;
+      });
+  const once = U.Control && typeof U.Control.once === 'function'
+    ? U.Control.once
+    : ((fn) => {
+        let called = false;
+        let value;
+        return function onceWrapper() {
+          if (!called) {
+            called = true;
+            value = fn.apply(this, arguments);
+          }
+          return value;
+        };
+      });
+
+  const registry = new WeakMap();
+  const scheduled = new Set();
+  let cdnUrl = 'https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js';
+
+  const warnedPaths = new Set();
+
+  function warnNonSerializable(path, kind) {
+    if (!path) return;
+    const key = Array.isArray(path) ? path.join('.') : String(path);
+    if (warnedPaths.has(key)) return;
+    warnedPaths.add(key);
+    if (M.Auditor && typeof M.Auditor.warn === 'function') {
+      M.Auditor.warn('W-CHART-SERIAL', 'تم تجاهل قيمة غير قابلة للنسخ ضمن إعدادات Chart.js', {
+        path: key,
+        kind: kind || typeof kind
+      });
+    }
+  }
+
+  function sanitizeValue(value, path) {
+    if (value == null) return value;
+    const type = typeof value;
+    if (type === 'function') {
+      warnNonSerializable(path, 'function');
+      return null;
+    }
+    if (type !== 'object') {
+      return value;
+    }
+    if (value instanceof Date) {
+      return new Date(value.getTime());
+    }
+    if (Array.isArray(value)) {
+      return value.map((item, index) => sanitizeValue(item, (path || []).concat(index)));
+    }
+    const out = {};
+    Object.keys(value).forEach((key) => {
+      out[key] = sanitizeValue(value[key], (path || []).concat(key));
+    });
+    return out;
+  }
+
+  const formatterResolvers = {
+    percent: (descriptor) => {
+      const digits = Number.isFinite(descriptor?.digits) ? descriptor.digits : 0;
+      const suffix = typeof descriptor?.suffix === 'string' ? descriptor.suffix : '%';
+      const scale = Number.isFinite(descriptor?.scale) ? descriptor.scale : 1;
+      return (value) => {
+        const numeric = typeof value === 'number' ? value : parseFloat(value);
+        if (Number.isFinite(numeric)) {
+          const scaled = numeric * scale;
+          const formatted = Number.isFinite(digits) ? scaled.toFixed(digits) : String(scaled);
+          return `${formatted}${suffix}`;
+        }
+        return `${value}${suffix}`;
+      };
+    },
+    currency: (descriptor) => {
+      const currency = typeof descriptor?.currency === 'string' ? descriptor.currency : 'USD';
+      const locale = typeof descriptor?.locale === 'string' ? descriptor.locale : undefined;
+      const digits = Number.isFinite(descriptor?.digits) ? descriptor.digits : 0;
+      const formatter = new Intl.NumberFormat(locale, {
+        style: 'currency',
+        currency,
+        minimumFractionDigits: digits,
+        maximumFractionDigits: digits
+      });
+      return (value) => {
+        const numeric = typeof value === 'number' ? value : parseFloat(value);
+        if (Number.isFinite(numeric)) {
+          return formatter.format(numeric);
+        }
+        return formatter.format(0);
+      };
+    },
+    compact: (descriptor) => {
+      const locale = typeof descriptor?.locale === 'string' ? descriptor.locale : undefined;
+      const digits = Number.isFinite(descriptor?.digits) ? descriptor.digits : 1;
+      const formatter = new Intl.NumberFormat(locale, {
+        notation: 'compact',
+        maximumFractionDigits: digits
+      });
+      return (value) => {
+        const numeric = typeof value === 'number' ? value : parseFloat(value);
+        if (Number.isFinite(numeric)) {
+          return formatter.format(numeric);
+        }
+        return formatter.format(0);
+      };
+    }
+  };
+
+  function isFormatterDescriptor(value) {
+    return value && typeof value === 'object' && !Array.isArray(value) && typeof value.__chartFormatter === 'string';
+  }
+
+  function resolveFormatter(descriptor) {
+    const resolver = formatterResolvers[descriptor?.__chartFormatter];
+    if (typeof resolver === 'function') {
+      return resolver(descriptor);
+    }
+    return null;
+  }
+
+  function reviveScriptables(target) {
+    if (!target) return target;
+    if (Array.isArray(target)) {
+      for (let i = 0; i < target.length; i += 1) {
+        target[i] = reviveScriptables(target[i]);
+      }
+      return target;
+    }
+    if (typeof target !== 'object') {
+      return target;
+    }
+    if (isFormatterDescriptor(target)) {
+      const fn = resolveFormatter(target);
+      return fn || target;
+    }
+    Object.keys(target).forEach((key) => {
+      const value = target[key];
+      if ((key === 'callback' || key === 'formatter' || key === 'generateLabel' || key === 'label') && isFormatterDescriptor(value)) {
+        const fn = resolveFormatter(value);
+        if (fn) {
+          target[key] = fn;
+          return;
+        }
+      }
+      target[key] = reviveScriptables(value);
+    });
+    return target;
+  }
+
+  const loadLibraryOnce = once(() => {
+    if (typeof document === 'undefined') return Promise.resolve(null);
+    if (globalObj.Chart && typeof globalObj.Chart === 'function') {
+      return Promise.resolve(globalObj.Chart);
+    }
+    return new Promise((resolve, reject) => {
+      try {
+        const script = document.createElement('script');
+        script.src = cdnUrl;
+        script.async = true;
+        script.onload = () => resolve(globalObj.Chart || null);
+        script.onerror = (err) => reject(err);
+        document.head.appendChild(script);
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+
+  function ensureLibrary() {
+    if (globalObj.Chart && typeof globalObj.Chart === 'function') {
+      return Promise.resolve(globalObj.Chart);
+    }
+    return loadLibraryOnce().catch((err) => {
+      if (M.Auditor && typeof M.Auditor.warn === 'function') {
+        M.Auditor.warn('W-CHART', 'تعذر تحميل مكتبة Chart.js', { error: String(err) });
+      }
+      return null;
+    });
+  }
+
+  function encodePayload(payload) {
+    return stableStringify(payload || {});
+  }
+
+  function buildPayload(type, data, options) {
+    const safeData = (data && typeof data === 'object') ? sanitizeValue(data, ['data']) : { labels: [], datasets: [] };
+    if (!Array.isArray(safeData.datasets)) safeData.datasets = [];
+    const baseOptions = {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: 'index', intersect: false },
+      plugins: {
+        legend: {
+          display: true,
+          position: 'bottom',
+          labels: {
+            usePointStyle: true,
+            boxWidth: 12,
+            boxHeight: 12
+          }
+        }
+      },
+      scales: {
+        x: {
+          grid: { display: false },
+          ticks: { color: 'rgba(71,85,105,0.75)' }
+        },
+        y: {
+          grid: { color: 'rgba(148,163,184,0.18)' },
+          ticks: { color: 'rgba(71,85,105,0.75)', beginAtZero: true }
+        }
+      },
+      elements: {
+        line: { borderWidth: 2, tension: 0.4 },
+        point: { radius: 3, hoverRadius: 6 }
+      }
+    };
+    const safeOptions = (options && typeof options === 'object') ? sanitizeValue(options, ['options']) : {};
+    const merged = deepMerge(baseOptions, safeOptions);
+    return { type, data: safeData, options: merged };
+  }
+
+  function instantiate(node, signature, payload, ChartLib) {
+    if (!node || !ChartLib) return null;
+    const ctx = node.getContext ? node.getContext('2d') : null;
+    if (!ctx) return null;
+    const current = registry.get(node);
+    if (current && current.signature === signature) {
+      return current.instance;
+    }
+    if (current && current.instance && typeof current.instance.destroy === 'function') {
+      try { current.instance.destroy(); } catch (_err) { /* ignore */ }
+    }
+    try {
+      const config = {
+        type: payload.type,
+        data: clone(payload.data),
+        options: clone(payload.options)
+      };
+      reviveScriptables(config.data);
+      reviveScriptables(config.options);
+      const chart = new ChartLib(ctx, config);
+      registry.set(node, { instance: chart, signature });
+      return chart;
+    } catch (err) {
+      if (M.Auditor && typeof M.Auditor.error === 'function') {
+        M.Auditor.error('E-CHART', 'فشل إنشاء الرسم البياني', { error: String(err) });
+      }
+      return null;
+    }
+  }
+
+  function hydrateNow(root) {
+    if (typeof document === 'undefined') return;
+    const scope = (!root || root === document) ? document : root;
+    const nodes = scope.querySelectorAll ? scope.querySelectorAll('[data-m-chart]') : [];
+    if (!nodes.length) return;
+    ensureLibrary().then((ChartLib) => {
+      if (!ChartLib) return;
+      nodes.forEach((node) => {
+        const raw = node.getAttribute('data-m-chart');
+        if (!raw) return;
+        const payload = parseSafe(raw, null);
+        if (!payload || !payload.type) return;
+        instantiate(node, raw, payload, ChartLib);
+      });
+    });
+  }
+
+  function scheduleHydrate(root) {
+    if (typeof window === 'undefined') return;
+    const key = root || document;
+    if (scheduled.has(key)) return;
+    scheduled.add(key);
+    const run = () => {
+      scheduled.delete(key);
+      hydrateNow(root || document);
+    };
+    if (typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(run);
+    } else {
+      setTimeout(run, 16);
+    }
+  }
+
+  function bindApp(app, mount) {
+    if (!app || typeof document === 'undefined') return null;
+    const resolveRoot = () => {
+      if (typeof mount === 'string') {
+        return document.querySelector(mount) || document;
+      }
+      return mount || document;
+    };
+    const target = resolveRoot();
+    scheduleHydrate(target);
+    const original = app.rebuild;
+    app.rebuild = function patchedRebuild() {
+      const result = original.apply(app, arguments);
+      scheduleHydrate(resolveRoot());
+      return result;
+    };
+    return {
+      unbind() {
+        app.rebuild = original;
+      }
+    };
+  }
+
+  function setCDN(url) {
+    if (typeof url === 'string' && url.trim()) {
+      cdnUrl = url.trim();
+    }
+  }
+
+  const formatters = {
+    percent: (digits = 0, options = {}) => ({ __chartFormatter: 'percent', digits, suffix: typeof options.suffix === 'string' ? options.suffix : '%', scale: Number.isFinite(options.scale) ? options.scale : 1 }),
+    currency: (currency = 'USD', options = {}) => ({ __chartFormatter: 'currency', currency, locale: options.locale, digits: Number.isFinite(options.digits) ? options.digits : 0 }),
+    compact: (digits = 1, options = {}) => ({ __chartFormatter: 'compact', digits, locale: options.locale })
+  };
+
+  return { buildPayload, encodePayload, hydrate: scheduleHydrate, bindApp, ensureLibrary, setCDN, formatters };
+})();
+
+function ChartCanvas({ type='line', data, options, attrs={}, height=320, description, id }) {
+  const payload = ChartBridge.buildPayload(type, data, options);
+  const baseClass = cx('mishkah-chart-canvas', tw`block w-full`);
+  const canvasAttrs = withClass(attrs, baseClass);
+  canvasAttrs['data-m-chart'] = ChartBridge.encodePayload(payload);
+  canvasAttrs['data-chart-type'] = type;
+  if (description && !('aria-label' in canvasAttrs)) {
+    canvasAttrs['aria-label'] = description;
+  }
+  if (id && !('id' in canvasAttrs)) {
+    canvasAttrs.id = id;
+  }
+  const style = canvasAttrs.style ? String(canvasAttrs.style) + ';' : '';
+  if (height != null && height !== false) {
+    if (!('height' in canvasAttrs)) canvasAttrs.height = height;
+    canvasAttrs.style = `${style}min-height:${height}px;`; // keep intrinsic height
+  } else if (style) {
+    canvasAttrs.style = style;
+  }
+  if (!('role' in canvasAttrs)) {
+    canvasAttrs.role = 'img';
+  }
+  return h.Embedded.Canvas({ attrs: canvasAttrs });
+}
+
+function createChartFactory(defaultType) {
+  return (config={}) => ChartCanvas(Object.assign({ type: defaultType }, config));
+}
+
+const ChartAPI = Object.assign({
+  Canvas: ChartCanvas,
+  factory: createChartFactory,
+  Line: createChartFactory('line'),
+  Bar: createChartFactory('bar'),
+  Doughnut: createChartFactory('doughnut'),
+  Pie: createChartFactory('pie'),
+  Radar: createChartFactory('radar'),
+  PolarArea: createChartFactory('polarArea')
+}, ChartBridge);
+
+ChartAPI.formatters = Object.assign({}, ChartBridge.formatters);
+
+UI.Chart = ChartAPI;
+UI.Charts = ChartAPI;
+
 UI.AppRoot = ({ shell, overlays }) =>
   h.Containers.Div({ attrs:{ class: tw`${token('surface')} flex h-screen min-h-screen flex-col overflow-hidden` }}, [ shell, ...(overlays||[]) ]);
 
@@ -503,14 +898,14 @@ UI.Tabs = ({ items=[], activeId, gkey='ui:tabs:select' })=>{
   return UI.VStack({}, [header, ...panels]);
 };
 
-UI.Drawer = ({ open=false, side='start', header, content })=>{
+UI.Drawer = ({ open=false, side='start', header, content, closeGkey='ui:drawer:close' })=>{
   if(!open) return h.Containers.Div({ attrs:{ class: tw`hidden` }});
   const isRTL = (document.documentElement.getAttribute('dir')||'ltr')==='rtl';
   const start = isRTL? 'right-0':'left-0';
   const end   = isRTL? 'left-0':'right-0';
   const place = side==='start'? start: end;
   return h.Containers.Div({ attrs:{ class: tw`${token('modal-root')}` }}, [
-    h.Containers.Div({ attrs:{ class: tw`absolute inset-0`, gkey:'ui:drawer:close' }}, [
+    h.Containers.Div({ attrs:{ class: tw`absolute inset-0`, gkey:closeGkey }}, [
       h.Containers.Div({ attrs:{ class: tw`${token('backdrop')}` }})
     ]),
     h.Containers.Aside({ attrs:{ class: tw`${token('drawer/side')} ${place}` }}, [

--- a/mishkah.templates.js
+++ b/mishkah.templates.js
@@ -216,6 +216,165 @@
 .template-footer__links { display: flex; flex-wrap: wrap; gap: 0.75rem 1.25rem; }
 .template-footer__link { color: color-mix(in oklab, var(--muted-foreground) 92%, transparent); font-size: 0.95rem; }
 .template-footer__link:hover { color: var(--foreground); }
+.mishkah-dashboard {
+  position: relative;
+  min-height: 100vh;
+  background: linear-gradient(160deg, color-mix(in oklab, var(--background) 94%, transparent) 0%, color-mix(in oklab, var(--surface-1) 88%, transparent) 100%);
+}
+.dark .mishkah-dashboard {
+  background: linear-gradient(160deg, color-mix(in oklab, var(--background) 92%, black) 0%, color-mix(in oklab, var(--surface-2) 90%, transparent) 100%);
+}
+.mishkah-dashboard::before {
+  content: '';
+  position: fixed;
+  inset: auto;
+  width: 520px;
+  height: 520px;
+  top: -220px;
+  right: -140px;
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(79,70,229,0.15), transparent 70%);
+  opacity: 0.55;
+  pointer-events: none;
+  z-index: 0;
+}
+.dashboard-stat-grid { display: grid; gap: 1rem; }
+@media (min-width: 768px) { .dashboard-stat-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); } }
+.dashboard-secondary-grid { display: grid; gap: 1rem; }
+.dashboard-secondary-grid > * { height: 100%; }
+.mishkah-dashboard-card {
+  border-radius: 24px;
+  background: color-mix(in oklab, var(--surface-1) 90%, transparent);
+  border: 1px solid color-mix(in oklab, var(--border) 55%, transparent);
+  box-shadow: 0 28px 68px -38px rgba(15, 23, 42, 0.32);
+  backdrop-filter: blur(26px);
+}
+.dark .mishkah-dashboard-card {
+  background: color-mix(in oklab, var(--surface-2) 92%, transparent);
+  border-color: color-mix(in oklab, var(--border) 58%, transparent);
+  box-shadow: 0 32px 70px -36px rgba(15, 23, 42, 0.6);
+}
+.mishkah-chart-canvas {
+  background: color-mix(in oklab, var(--surface-1) 92%, transparent);
+  border-radius: 1.25rem;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.12), 0 18px 48px -32px rgba(15,23,42,0.45);
+}
+.dark .mishkah-chart-canvas {
+  background: color-mix(in oklab, var(--surface-2) 94%, transparent);
+  box-shadow: inset 0 1px 0 rgba(15,23,42,0.35), 0 24px 56px -34px rgba(15,23,42,0.65);
+}
+.mishkah-mobile {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2.5rem 1.25rem;
+  background: radial-gradient(circle at 10% 20%, rgba(59,130,246,0.16), transparent 60%), linear-gradient(180deg, color-mix(in oklab, var(--background) 95%, transparent) 0%, color-mix(in oklab, var(--surface-1) 86%, transparent) 100%);
+}
+.dark .mishkah-mobile {
+  background: radial-gradient(circle at 15% 15%, rgba(129,140,248,0.25), transparent 65%), linear-gradient(185deg, color-mix(in oklab, var(--background) 92%, black) 0%, color-mix(in oklab, var(--surface-2) 90%, transparent) 100%);
+}
+.mishkah-mobile-shell {
+  position: relative;
+  width: min(420px, 100%);
+  border-radius: 2.5rem;
+  padding: 1.5rem;
+  border: 1px solid color-mix(in oklab, var(--border) 58%, transparent);
+  background: color-mix(in oklab, var(--surface-1) 92%, transparent);
+  box-shadow: 0 28px 60px -34px rgba(15, 23, 42, 0.45);
+  overflow: hidden;
+}
+.dark .mishkah-mobile-shell {
+  background: color-mix(in oklab, var(--surface-2) 94%, transparent);
+  border-color: color-mix(in oklab, var(--border) 60%, transparent);
+  box-shadow: 0 34px 70px -36px rgba(15, 23, 42, 0.7);
+}
+.mishkah-mobile-shell::before {
+  content: '';
+  position: absolute;
+  inset: -45% -40% auto;
+  height: 140%;
+  background: radial-gradient(circle, rgba(59,130,246,0.18), transparent 68%);
+  opacity: 0.45;
+}
+.mishkah-mobile-content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+.mobile-balance-card {
+  border-radius: 1.5rem;
+  padding: 1.25rem;
+  background: linear-gradient(160deg, rgba(59,130,246,0.18), rgba(37,99,235,0.12));
+  color: rgba(15,23,42,0.92);
+  box-shadow: 0 24px 56px -32px rgba(37, 99, 235, 0.45);
+}
+.dark .mobile-balance-card {
+  background: linear-gradient(160deg, rgba(129,140,248,0.35), rgba(14,116,144,0.22));
+  color: rgba(226,232,240,0.95);
+  box-shadow: 0 28px 64px -34px rgba(15,23,42,0.7);
+}
+.mobile-status-bar { display: flex; align-items: center; justify-content: space-between; font-size: 0.85rem; color: color-mix(in oklab, var(--foreground) 88%, transparent); }
+.mobile-quick-actions { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 0.75rem; }
+.mobile-action-btn {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: center;
+  justify-content: center;
+  padding: 0.9rem;
+  border-radius: 1.25rem;
+  background: color-mix(in oklab, var(--surface-2) 90%, transparent);
+  box-shadow: 0 18px 40px -30px rgba(15, 23, 42, 0.4);
+}
+.dark .mobile-action-btn {
+  background: color-mix(in oklab, var(--surface-2) 94%, transparent);
+  box-shadow: 0 22px 44px -32px rgba(15, 23, 42, 0.6);
+}
+.mobile-highlight-card {
+  border-radius: 1.25rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  border: 1px solid color-mix(in oklab, var(--border) 58%, transparent);
+  background: color-mix(in oklab, var(--surface-1) 94%, transparent);
+}
+.dark .mobile-highlight-card {
+  background: color-mix(in oklab, var(--surface-2) 95%, transparent);
+  border-color: color-mix(in oklab, var(--border) 60%, transparent);
+}
+.mobile-transaction {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.85rem 0;
+  border-bottom: 1px solid color-mix(in oklab, var(--border) 55%, transparent);
+}
+.mobile-transaction:last-child { border-bottom: none; }
+.mobile-page-tabs { display: flex; justify-content: center; }
+.mobile-page-tabs .ui-switcher { width: 100%; }
+.mobile-menu-toggle { display: inline-flex; align-items: center; justify-content: center; width: 2.5rem; height: 2.5rem; border-radius: 9999px; background: color-mix(in oklab, var(--surface-2) 92%, transparent); box-shadow: 0 12px 26px -18px rgba(15,23,42,0.55); }
+.dark .mobile-menu-toggle { background: color-mix(in oklab, var(--surface-2) 96%, transparent); box-shadow: 0 14px 30px -18px rgba(15,23,42,0.7); }
+.mobile-menu-header { display: flex; align-items: center; gap: 0.85rem; padding-bottom: 0.5rem; border-bottom: 1px solid color-mix(in oklab, var(--border) 55%, transparent); }
+.mobile-menu-body { display: flex; flex-direction: column; gap: 1.25rem; padding-top: 0.75rem; }
+.mobile-menu-items { display: flex; flex-direction: column; gap: 0.5rem; }
+.mobile-menu-item { display: flex; align-items: center; justify-content: space-between; padding: 0.75rem 0.95rem; border-radius: 1rem; background: color-mix(in oklab, var(--surface-1) 94%, transparent); border: 1px solid transparent; transition: background 0.2s ease, border 0.2s ease; }
+.mobile-menu-item .item-label { display: flex; align-items: center; gap: 0.75rem; font-weight: 500; }
+.mobile-menu-item .item-icon { display: inline-flex; width: 2.1rem; height: 2.1rem; border-radius: 9999px; align-items: center; justify-content: center; background: color-mix(in oklab, var(--surface-2) 90%, transparent); }
+.mobile-menu-item.is-active { border-color: color-mix(in oklab, var(--primary) 55%, transparent); background: color-mix(in oklab, var(--primary) 18%, transparent); color: color-mix(in oklab, var(--primary) 95%, var(--foreground)); }
+.dark .mobile-menu-item { background: color-mix(in oklab, var(--surface-2) 96%, transparent); }
+.mobile-menu-preferences { display: flex; flex-direction: column; gap: 0.5rem; }
+.mobile-menu-pref { display: flex; align-items: center; justify-content: space-between; padding: 0.65rem 0.85rem; border-radius: 0.9rem; background: color-mix(in oklab, var(--surface-1) 94%, transparent); }
+.mobile-menu-footer { display: flex; flex-direction: column; gap: 0.5rem; padding-top: 0.5rem; border-top: 1px dashed color-mix(in oklab, var(--border) 50%, transparent); }
+.mobile-bottom-nav { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 0.75rem; padding-top: 1.25rem; }
+.mobile-bottom-nav button { display: flex; flex-direction: column; gap: 0.2rem; align-items: center; justify-content: center; padding: 0.65rem 0.5rem; border-radius: 1rem; background: color-mix(in oklab, var(--surface-1) 94%, transparent); border: 1px solid transparent; font-size: 0.75rem; }
+.mobile-bottom-nav button .icon { font-size: 1.1rem; }
+.mobile-bottom-nav button.is-active { border-color: color-mix(in oklab, var(--primary) 55%, transparent); background: color-mix(in oklab, var(--primary) 20%, transparent); color: color-mix(in oklab, var(--primary) 90%, var(--foreground)); }
+.dark .mobile-bottom-nav button { background: color-mix(in oklab, var(--surface-2) 95%, transparent); }
 .template-atlas-sidebar { background: color-mix(in oklab, var(--surface-2) 92%, transparent); backdrop-filter: blur(28px); border-inline-end: 1px solid color-mix(in oklab, var(--border) 55%, transparent); }
 .dark .template-atlas-sidebar { background: color-mix(in oklab, var(--surface-2) 96%, transparent); }
 .template-atlas-sidebar .template-timeline__item { border-bottom: 1px solid color-mix(in oklab, var(--border) 50%, transparent); padding-bottom: 1.25rem; }
@@ -430,6 +589,869 @@
     }
   };
 
+  const DEFAULT_DASHBOARD_COPY = {
+    brand: {
+      name: 'Mishkah Analytics',
+      subtitle: 'تقرير الأداء الأسبوعي',
+      initials: 'MA'
+    },
+    filters: {
+      activeRange: '7d',
+      searchPlaceholder: 'ابحث في لوحة التحكم',
+      user: 'ليلى أحمد',
+      ranges: [
+        { id: '24h', label: 'آخر ٢٤ ساعة' },
+        { id: '7d', label: 'آخر ٧ أيام' },
+        { id: '30d', label: 'آخر ٣٠ يوم' }
+      ],
+      primaryAction: { label: 'تصدير التقرير', gkey: 'dashboard:export' }
+    },
+    stats: [
+      { id: 'visits', title: 'الزيارات', value: '38,240', meta: '+14% عن الأسبوع الماضي' },
+      { id: 'signups', title: 'التسجيلات الجديدة', value: '1,204', meta: '+6% نمو' },
+      { id: 'conversion', title: 'نسبة التحويل', value: '4.2%', meta: '+0.8 نقطة' },
+      { id: 'retention', title: 'الاحتفاظ', value: '86%', meta: 'ثابت' }
+    ],
+    charts: {
+      performance: {
+        title: 'أداء القنوات الرقمية',
+        subtitle: 'النمو الأسبوعي للزيارات والتحويلات',
+        height: 320,
+        data: {
+          labels: ['الأحد', 'الإثنين', 'الثلاثاء', 'الأربعاء', 'الخميس', 'الجمعة', 'السبت'],
+          datasets: [
+            {
+              label: 'الزيارات',
+              data: [180, 240, 265, 310, 332, 360, 384],
+              fill: true,
+              backgroundColor: 'rgba(59,130,246,0.18)',
+              borderColor: 'rgba(59,130,246,1)',
+              pointBackgroundColor: 'rgba(59,130,246,1)'
+            },
+            {
+              label: 'التسجيلات',
+              data: [48, 62, 70, 82, 88, 94, 108],
+              fill: false,
+              borderColor: 'rgba(16,185,129,1)',
+              backgroundColor: 'rgba(16,185,129,0.24)',
+              pointBackgroundColor: 'rgba(16,185,129,1)'
+            }
+          ]
+        },
+        options: {
+          plugins: { legend: { position: 'bottom' } },
+          scales: { y: { suggestedMax: 400 } }
+        }
+      },
+      conversion: {
+        title: 'معدل التحويل لكل قناة',
+        subtitle: 'مقارنة بين الحملات الأساسية',
+        height: 220,
+        data: {
+          labels: ['البريد', 'الإعلانات', 'الشركاء', 'التواصل'],
+          datasets: [
+            {
+              label: 'تسجيلات',
+              data: [85, 64, 48, 38],
+              backgroundColor: [
+                'rgba(56,189,248,0.78)',
+                'rgba(129,140,248,0.85)',
+                'rgba(16,185,129,0.82)',
+                'rgba(251,191,36,0.82)'
+              ],
+              borderRadius: 14
+            }
+          ]
+        },
+        options: {
+          plugins: { legend: { display: false } },
+          scales: { y: { beginAtZero: true, ticks: { stepSize: 20 } } }
+        }
+      },
+      breakdown: {
+        title: 'توزيع الأجهزة',
+        subtitle: 'نسبة المستخدمين بحسب الجهاز',
+        height: 220,
+        data: {
+          labels: ['الهاتف', 'الحاسوب', 'الأجهزة اللوحية'],
+          datasets: [
+            {
+              data: [54, 34, 12],
+              backgroundColor: ['#6366F1', '#10B981', '#F59E0B'],
+              borderWidth: 0
+            }
+          ]
+        },
+        options: {
+          plugins: { legend: { position: 'right' } }
+        }
+      }
+    },
+    table: {
+      title: 'أفضل القنوات',
+      subtitle: 'أداء الحملات خلال الفترة المختارة',
+      columns: [
+        { key: 'channel', label: 'القناة' },
+        { key: 'sessions', label: 'الزيارات' },
+        { key: 'signups', label: 'التسجيلات' },
+        { key: 'rate', label: 'التحويل' }
+      ],
+      rows: [
+        { channel: 'البريد الإلكتروني', sessions: '12,350', signups: '640', rate: '5.2%' },
+        { channel: 'الإعلانات المدفوعة', sessions: '9,180', signups: '420', rate: '4.6%' },
+        { channel: 'الشركاء', sessions: '6,420', signups: '318', rate: '5.0%' },
+        { channel: 'وسائل التواصل', sessions: '5,760', signups: '226', rate: '3.9%' }
+      ],
+      action: { label: 'عرض جميع القنوات', gkey: 'dashboard:table:action' }
+    },
+    activity: {
+      title: 'المهام السريعة',
+      subtitle: 'تابع أهم المهام للفريق',
+      items: [
+        { id: 'campaign', icon: '🎯', title: 'إطلاق حملة رمضان', status: 'جاهز للنشر', due: 'اليوم' },
+        { id: 'ux', icon: '🧪', title: 'مراجعة تجربة الدفع', status: 'قيد التنفيذ', due: 'غدًا' },
+        { id: 'report', icon: '📈', title: 'تقرير أسبوعي للإدارة', status: 'قيد المراجعة', due: 'الخميس' }
+      ]
+    }
+  };
+
+  const DASHBOARD_DEFAULT_OPTIONS = {
+    layout: 'command',
+    mount: '#app',
+    theme: 'light',
+    lang: 'ar',
+    scaffold: true
+  };
+
+  const DashboardSections = {
+    topbar: (ctx) => {
+      const { D, UI, tw, cx, ensureDict, toArr, token } = ctx.helpers;
+      const brand = ensureDict(ctx.copy.brand);
+      const filters = ensureDict(ctx.copy.filters);
+      const ranges = toArr(filters.ranges);
+      const activeRange = ctx.db?.ui?.activeRange || filters.activeRange || (ranges[0] && (ranges[0].id || ranges[0].value));
+
+      const initials = brand.initials || (brand.name ? brand.name.slice(0, 2).toUpperCase() : 'MS');
+      const badge = D.Containers.Div({ attrs: { class: tw`grid h-11 w-11 place-items-center rounded-2xl bg-[color-mix(in oklab,var(--primary) 90%, transparent)] text-lg font-semibold text-[var(--primary)] shadow-sm` } }, [
+        brand.icon ? D.Text.Span({}, [brand.icon]) : D.Text.Span({}, [initials])
+      ]);
+
+      const brandBlock = D.Containers.Div({ attrs: { class: tw`flex flex-col gap-0.5` } }, [
+        D.Text.Span({ attrs: { class: tw`text-sm font-semibold` } }, [brand.name || 'Mishkah Analytics']),
+        brand.subtitle ? D.Text.Span({ attrs: { class: tw`text-xs ${token('muted')}` } }, [brand.subtitle]) : null
+      ].filter(Boolean));
+
+      const left = D.Containers.Div({ attrs: { class: tw`flex items-center gap-3` } }, [badge, brandBlock]);
+
+      const rangeSelector = ranges.length
+        ? UI.Segmented({
+            items: ranges.map((range, idx) => ({
+              id: range.id || range.value || `range-${idx}`,
+              label: range.label || range.title || `Range ${idx + 1}`,
+              gkey: range.gkey || 'dashboard:filters:range',
+              attrs: { 'data-range-id': range.id || range.value || `range-${idx}` }
+            })),
+            activeId: activeRange,
+            attrs: { class: tw`hidden md:flex bg-[color-mix(in oklab,var(--surface-2) 88%, transparent)]` }
+          })
+        : null;
+
+      const controls = [
+        filters.searchPlaceholder
+          ? UI.SearchBar({
+              placeholder: filters.searchPlaceholder,
+              attrs: { class: tw`hidden lg:flex w-[260px]` },
+              onInput: filters.searchGkey || 'dashboard:search'
+            })
+          : null,
+        rangeSelector,
+        filters.user ? UI.Badge({ variant: 'badge/ghost', text: filters.user, attrs: { class: tw`hidden sm:inline-flex` } }) : null,
+        filters.primaryAction && filters.primaryAction.label
+          ? UI.Button({ attrs: { gkey: filters.primaryAction.gkey || 'dashboard:export' }, variant: 'solid', size: 'sm' }, [filters.primaryAction.label])
+          : null
+      ].filter(Boolean);
+
+      const right = D.Containers.Div({ attrs: { class: tw`flex flex-wrap items-center justify-end gap-2` } }, controls);
+
+      return UI.Toolbar({ left: [left], right: [right] });
+    },
+
+    stats: (ctx) => {
+      const { D, UI, tw, cx, toArr, ensureDict } = ctx.helpers;
+      const stats = toArr(ctx.copy.stats);
+      if (!stats.length) return null;
+      const cards = stats.map((entry, idx) => {
+        const item = ensureDict(entry);
+        return UI.StatCard({
+          title: item.title || item.label || `المؤشر ${idx + 1}`,
+          value: item.value || '0',
+          meta: item.meta || item.hint
+        });
+      });
+      return D.Containers.Section({ attrs: { class: cx('mishkah-dashboard-card', tw`p-4 md:p-6`) } }, [
+        D.Containers.Div({ attrs: { class: 'dashboard-stat-grid' } }, cards)
+      ]);
+    },
+
+    primaryChart: (ctx) => {
+      const { D, UI, tw, ensureDict, cx } = ctx.helpers;
+      const perf = ensureDict(ctx.copy.charts && ctx.copy.charts.performance);
+      if (!Object.keys(perf).length) return null;
+      const height = perf.height || 320;
+      const chart = UI.Chart.Line({
+        data: perf.data,
+        options: perf.options,
+        height,
+        attrs: { 'data-chart-key': 'dashboard:performance' },
+        description: perf.title
+      });
+      const header = D.Containers.Div({ attrs: { class: tw`space-y-1` } }, [
+        perf.title ? D.Text.H3({ attrs: { class: tw`text-base font-semibold` } }, [perf.title]) : null,
+        perf.subtitle ? D.Text.P({ attrs: { class: tw`text-sm text-[var(--muted-foreground)]` } }, [perf.subtitle]) : null
+      ].filter(Boolean));
+      const bodyAttrs = { class: tw`flex-1`, style: `min-height:${height}px;` };
+      return D.Containers.Section({ attrs: { class: cx('mishkah-dashboard-card', tw`flex h-full flex-col gap-4 p-6`) } }, [
+        header,
+        D.Containers.Div({ attrs: bodyAttrs }, [chart])
+      ]);
+    },
+
+    secondaryCharts: (ctx) => {
+      const { D, UI, tw, ensureDict, cx } = ctx.helpers;
+      const conversion = ensureDict(ctx.copy.charts && ctx.copy.charts.conversion);
+      const breakdown = ensureDict(ctx.copy.charts && ctx.copy.charts.breakdown);
+      const cards = [];
+
+      if (Object.keys(conversion).length) {
+        const height = conversion.height || 220;
+        const chart = UI.Chart.Bar({
+          data: conversion.data,
+          options: conversion.options,
+          height,
+          attrs: { 'data-chart-key': 'dashboard:conversion' },
+          description: conversion.title
+        });
+        cards.push(D.Containers.Section({ attrs: { class: cx('mishkah-dashboard-card', tw`flex flex-col gap-4 p-6`) } }, [
+          conversion.title ? D.Text.H3({ attrs: { class: tw`text-base font-semibold` } }, [conversion.title]) : null,
+          conversion.subtitle ? D.Text.P({ attrs: { class: tw`text-xs text-[var(--muted-foreground)]` } }, [conversion.subtitle]) : null,
+          D.Containers.Div({ attrs: { class: tw`flex-1`, style: `min-height:${height}px;` } }, [chart])
+        ].filter(Boolean)));
+      }
+
+      if (Object.keys(breakdown).length) {
+        const height = breakdown.height || 220;
+        const chart = UI.Chart.Doughnut({
+          data: breakdown.data,
+          options: breakdown.options,
+          height,
+          attrs: { 'data-chart-key': 'dashboard:breakdown' },
+          description: breakdown.title
+        });
+        cards.push(D.Containers.Section({ attrs: { class: cx('mishkah-dashboard-card', tw`flex flex-col gap-4 p-6`) } }, [
+          breakdown.title ? D.Text.H3({ attrs: { class: tw`text-base font-semibold` } }, [breakdown.title]) : null,
+          breakdown.subtitle ? D.Text.P({ attrs: { class: tw`text-xs text-[var(--muted-foreground)]` } }, [breakdown.subtitle]) : null,
+          D.Containers.Div({ attrs: { class: tw`flex-1 items-center justify-center`, style: `min-height:${height}px; display:flex;` } }, [chart])
+        ].filter(Boolean)));
+      }
+
+      if (!cards.length) return null;
+      return D.Containers.Div({ attrs: { class: 'dashboard-secondary-grid' } }, cards);
+    },
+
+    table: (ctx) => {
+      const { D, UI, tw, cx, ensureDict, toArr } = ctx.helpers;
+      const table = ensureDict(ctx.copy.table);
+      const columns = toArr(table.columns);
+      const rows = toArr(table.rows);
+      if (!columns.length || !rows.length) return null;
+      const footerAction = ensureDict(table.action);
+      const tableNode = D.Containers.Div({ attrs: { class: tw`overflow-x-auto` } }, [
+        UI.Table({ columns, rows })
+      ]);
+      const footer = footerAction.label
+        ? D.Containers.Div({ attrs: { class: tw`flex justify-end` } }, [
+            UI.Button({ attrs: { gkey: footerAction.gkey || 'dashboard:table:action' }, variant: 'ghost', size: 'sm' }, [footerAction.label])
+          ])
+        : null;
+      return D.Containers.Section({ attrs: { class: cx('mishkah-dashboard-card', tw`flex h-full flex-col gap-4 p-6`) } }, [
+        table.title ? D.Text.H3({ attrs: { class: tw`text-base font-semibold` } }, [table.title]) : null,
+        table.subtitle ? D.Text.P({ attrs: { class: tw`text-sm text-[var(--muted-foreground)]` } }, [table.subtitle]) : null,
+        tableNode,
+        footer
+      ].filter(Boolean));
+    },
+
+    activity: (ctx) => {
+      const { D, UI, tw, ensureDict, toArr } = ctx.helpers;
+      const activity = ensureDict(ctx.copy.activity);
+      const items = toArr(activity.items);
+      if (!items.length) return null;
+      const listItems = items.map((entry, idx) => {
+        const item = ensureDict(entry);
+        const leading = item.icon ? D.Text.Span({ attrs: { class: tw`text-lg` } }, [item.icon]) : null;
+        const content = [
+          item.title ? D.Text.Span({ attrs: { class: tw`text-sm font-semibold` } }, [item.title]) : null,
+          item.status ? D.Text.Span({ attrs: { class: tw`text-xs text-[var(--muted-foreground)]` } }, [item.status]) : null
+        ].filter(Boolean);
+        const trailing = item.due ? D.Text.Span({ attrs: { class: tw`text-xs text-[var(--muted-foreground)]` } }, [item.due]) : null;
+        return UI.ListItem({
+          leading,
+          content,
+          trailing,
+          attrs: { key: `activity-${item.id || idx}` }
+        });
+      });
+      return D.Containers.Section({ attrs: { class: cx('mishkah-dashboard-card', tw`flex h-full flex-col gap-4 p-6`) } }, [
+        activity.title ? D.Text.H3({ attrs: { class: tw`text-base font-semibold` } }, [activity.title]) : null,
+        activity.subtitle ? D.Text.P({ attrs: { class: tw`text-sm text-[var(--muted-foreground)]` } }, [activity.subtitle]) : null,
+        UI.List({ children: listItems })
+      ].filter(Boolean));
+    }
+  };
+
+  function LayoutDashboardCommand(ctx) {
+    const { D, tw, cx } = ctx.helpers;
+    const topbar = ctx.render('topbar');
+    const stats = ctx.render('stats');
+    const primary = ctx.render('primaryChart');
+    const secondary = ctx.render('secondaryCharts');
+    const table = ctx.render('table');
+    const activity = ctx.render('activity');
+
+    return D.Containers.Div({ attrs: { class: cx('mishkah-dashboard', tw`flex min-h-screen flex-col`) } }, [
+      D.Containers.Main({ attrs: { class: tw`relative z-10 mx-auto flex w-full max-w-7xl flex-1 flex-col gap-6 px-4 py-8 lg:px-10` } }, [
+        topbar,
+        stats,
+        D.Containers.Div({ attrs: { class: tw`grid gap-6 lg:grid-cols-[2fr_1fr]` } }, [primary, secondary].filter(Boolean)),
+        D.Containers.Div({ attrs: { class: tw`grid gap-6 lg:grid-cols-[2fr_1fr]` } }, [table, activity].filter(Boolean))
+      ].filter(Boolean))
+    ]);
+  }
+
+  const DashboardLayouts = { command: LayoutDashboardCommand };
+
+  const DEFAULT_MOBILE_COPY = {
+    statusBar: { time: '9:41', connectivity: '5G', battery: '🔋 82%' },
+    header: { greeting: 'مرحبًا، سارة', subtitle: 'الرصيد المتاح', avatar: '🪄' },
+    balance: {
+      amount: '24,800 ر.س',
+      change: '+12% هذا الأسبوع',
+      caption: 'آخر تحديث منذ دقيقة',
+      chart: {
+        type: 'line',
+        height: 140,
+        data: {
+          labels: ['أ', 'ب', 'ج', 'د', 'هـ', 'و', 'ز'],
+          datasets: [
+            {
+              label: 'الرصيد',
+              data: [18, 19, 21, 19, 22, 24, 25],
+              fill: true,
+              borderColor: 'rgba(129,140,248,1)',
+              backgroundColor: 'rgba(129,140,248,0.24)',
+              pointRadius: 0
+            }
+          ]
+        },
+        options: {
+          plugins: { legend: { display: false } },
+          scales: { x: { display: false }, y: { display: false } }
+        }
+      }
+    },
+    quickActions: [
+      { id: 'transfer', label: 'تحويل', icon: '↗️' },
+      { id: 'bill', label: 'دفع فاتورة', icon: '💡' },
+      { id: 'topup', label: 'شحن', icon: '➕' }
+    ],
+    highlights: [
+      { id: 'budget', title: 'الموازنة الشهرية', value: '68% مستهلك', meta: '2,450 ر.س متبقي' },
+      { id: 'savings', title: 'المدخرات الذكية', value: '8,200 ر.س', meta: '+450 ر.س هذا الشهر' }
+    ],
+    transactions: {
+      title: 'الحركات الأخيرة',
+      items: [
+        { id: 'uber', name: 'رحلة أوبر', time: 'اليوم • 09:24', amount: '-34 ر.س', type: 'out' },
+        { id: 'salary', name: 'إيداع راتب', time: 'أمس • 18:10', amount: '+8,500 ر.س', type: 'in' },
+        { id: 'market', name: 'سوبرماركت', time: 'أمس • 13:45', amount: '-240 ر.س', type: 'out' }
+      ],
+      action: { label: 'عرض الكل', gkey: 'mobile:transactions:all' }
+    },
+    pages: [
+      {
+        id: 'overview',
+        label: 'الرئيسية',
+        statusBar: { time: '9:41', connectivity: '5G', battery: '🔋 82%' },
+        header: { greeting: 'مرحبًا، سارة', subtitle: 'الرصيد المتاح', avatar: '🪄', pageTitle: 'الحسابات' },
+        balance: {
+          amount: '24,800 ر.س',
+          change: '+12% هذا الأسبوع',
+          caption: 'آخر تحديث منذ دقيقة',
+          chart: {
+            type: 'line',
+            height: 140,
+            data: {
+              labels: ['أ', 'ب', 'ج', 'د', 'هـ', 'و', 'ز'],
+              datasets: [
+                {
+                  label: 'الرصيد',
+                  data: [18, 19, 21, 19, 22, 24, 25],
+                  fill: true,
+                  borderColor: 'rgba(129,140,248,1)',
+                  backgroundColor: 'rgba(129,140,248,0.24)',
+                  pointRadius: 0
+                }
+              ]
+            },
+            options: {
+              plugins: { legend: { display: false } },
+              scales: { x: { display: false }, y: { display: false } }
+            }
+          }
+        },
+        quickActions: [
+          { id: 'transfer', label: 'تحويل', icon: '↗️' },
+          { id: 'bill', label: 'دفع فاتورة', icon: '💡' },
+          { id: 'topup', label: 'شحن', icon: '➕' }
+        ],
+        highlights: [
+          { id: 'budget', title: 'الموازنة الشهرية', value: '68% مستهلك', meta: '2,450 ر.س متبقي' },
+          { id: 'savings', title: 'المدخرات الذكية', value: '8,200 ر.س', meta: '+450 ر.س هذا الشهر' }
+        ],
+        transactions: {
+          title: 'الحركات الأخيرة',
+          items: [
+            { id: 'uber', name: 'رحلة أوبر', time: 'اليوم • 09:24', amount: '-34 ر.س', type: 'out' },
+            { id: 'salary', name: 'إيداع راتب', time: 'أمس • 18:10', amount: '+8,500 ر.س', type: 'in' },
+            { id: 'market', name: 'سوبرماركت', time: 'أمس • 13:45', amount: '-240 ر.س', type: 'out' }
+          ],
+          action: { label: 'عرض الكل', gkey: 'mobile:transactions:all' }
+        }
+      },
+      {
+        id: 'cards',
+        label: 'البطاقات',
+        header: { greeting: 'بطاقاتك', subtitle: 'الإدارة الذكية للبطاقات', avatar: '💳', pageTitle: 'إدارة البطاقات' },
+        quickActions: [
+          { id: 'freeze', label: 'إيقاف بطاقة', icon: '🛑' },
+          { id: 'limit', label: 'تعديل حدود', icon: '🎯' },
+          { id: 'new', label: 'إصدار جديدة', icon: '✨' }
+        ],
+        highlights: [
+          { id: 'visa', title: 'بطاقة Visa', value: '12,500 ر.س حد متاح', meta: 'آخر عملية أمس' },
+          { id: 'digital', title: 'البطاقة الرقمية', value: '4,300 ر.س حد متاح', meta: 'تم استخدامها 3 مرات هذا الأسبوع' }
+        ],
+        transactions: {
+          title: 'استخدام البطاقات',
+          items: [
+            { id: 'flight', name: 'حجز طيران', time: 'اليوم • 07:10', amount: '-1,240 ر.س', type: 'out' },
+            { id: 'refund', name: 'استرداد متجر', time: 'أمس • 19:40', amount: '+320 ر.س', type: 'in' },
+            { id: 'subscription', name: 'اشتراك منصّة', time: 'أمس • 11:05', amount: '-45 ر.س', type: 'out' }
+          ],
+          action: { label: 'إدارة البطاقات', gkey: 'mobile:cards:manage' }
+        }
+      },
+      {
+        id: 'insights',
+        label: 'التحليلات',
+        header: { greeting: 'رؤى مالية', subtitle: 'اتجاهات الإنفاق والادخار', avatar: '📊', pageTitle: 'لوحة التحليلات' },
+        balance: {
+          amount: '5,820 ر.س',
+          change: 'معدل ادخار 22%',
+          caption: 'ميزانية شهر رجب',
+          chart: {
+            type: 'bar',
+            height: 140,
+            data: {
+              labels: ['مواصلات', 'مطاعم', 'تسوق', 'سفر'],
+              datasets: [
+                {
+                  label: 'الإنفاق',
+                  data: [620, 540, 460, 380],
+                  borderRadius: 16,
+                  backgroundColor: ['rgba(56,189,248,0.75)', 'rgba(249,115,22,0.75)', 'rgba(129,140,248,0.78)', 'rgba(16,185,129,0.78)']
+                }
+              ]
+            },
+            options: {
+              plugins: { legend: { display: false } },
+              scales: { y: { beginAtZero: true } }
+            }
+          }
+        },
+        highlights: [
+          { id: 'trend', title: 'اتجاه الإنفاق', value: '−8% مقارنة بالشهر الماضي', meta: 'حافظ على المسار الحالي' },
+          { id: 'goal', title: 'الادخار السنوي', value: 'تم تحقيق 62%', meta: 'تبقّى 4 أشهر على الهدف' }
+        ],
+        transactions: {
+          title: 'التذكيرات القادمة',
+          items: [
+            { id: 'rent', name: 'دفعة إيجار', time: 'بعد 3 أيام', amount: '-4,200 ر.س', type: 'out' },
+            { id: 'investment', name: 'استثمار دوري', time: 'بعد أسبوع', amount: '-1,000 ر.س', type: 'out' },
+            { id: 'bonus', name: 'عائد أرباح', time: 'الشهر المقبل', amount: '+2,400 ر.س', type: 'in' }
+          ],
+          action: { label: 'إدارة التذكيرات', gkey: 'mobile:insights:reminders' }
+        }
+      }
+    ],
+    sideMenu: {
+      profile: { name: 'سارة العنزي', email: 'sara@mishkah.app', avatar: '🪄', badge: 'Premium' },
+      items: [
+        { id: 'overview', icon: '🏠', label: 'الرئيسية' },
+        { id: 'cards', icon: '💳', label: 'البطاقات' },
+        { id: 'insights', icon: '📊', label: 'التحليلات' }
+      ],
+      preferences: [
+        { id: 'theme', icon: '🌓', label: 'تبديل الثيم', gkey: 'ui:theme-toggle' },
+        { id: 'lang-ar', icon: '🇸🇦', label: 'العربية', gkey: 'ui:lang-ar' },
+        { id: 'lang-en', icon: '🇬🇧', label: 'English', gkey: 'ui:lang-en' }
+      ],
+      footer: { label: 'تسجيل الخروج', gkey: 'mobile:menu:logout' }
+    },
+    bottomNav: {
+      items: [
+        { id: 'overview', label: 'الرئيسية', icon: '🏠' },
+        { id: 'cards', label: 'البطاقات', icon: '💳' },
+        { id: 'insights', label: 'رؤى', icon: '📈' }
+      ]
+    }
+  };
+
+  const MOBILE_DEFAULT_OPTIONS = {
+    layout: 'neo',
+    mount: '#app',
+    theme: 'light',
+    lang: 'ar',
+    scaffold: true
+  };
+
+  const mobilePageKey = (page, fallback) => page?.id || page?.value || page?.slug || page?.code || fallback;
+
+  function getMobilePages(copy) {
+    return toArr(copy.pages).map((entry) => ensureDict(entry)).filter((entry) => Object.keys(entry).length);
+  }
+
+  function getActiveMobilePage(ctx) {
+    const pages = getMobilePages(ctx.copy);
+    if (!pages.length) return null;
+    const active = ctx.db?.ui?.activePage;
+    if (active) {
+      const found = pages.find((page, index) => mobilePageKey(page, `page-${index}`) === active);
+      if (found) return found;
+    }
+    return pages[0];
+  }
+
+  function resolveActivePageId(ctx) {
+    const pages = getMobilePages(ctx.copy);
+    if (!pages.length) return null;
+    const fallback = mobilePageKey(pages[0], 'page-0');
+    const active = ctx.db?.ui?.activePage;
+    if (active && pages.some((page, index) => mobilePageKey(page, `page-${index}`) === active)) {
+      return active;
+    }
+    return fallback;
+  }
+
+  function pickPageDict(ctx, key) {
+    const fallback = ensureDict(ctx.copy[key]);
+    const page = getActiveMobilePage(ctx);
+    if (!page) return fallback;
+    const override = ensureDict(page[key]);
+    if (!Object.keys(override).length) return fallback;
+    return mergeDeep(fallback, override);
+  }
+
+  function pickPageArray(ctx, key) {
+    const page = getActiveMobilePage(ctx);
+    const override = page ? toArr(page[key]) : [];
+    if (override.length) return override;
+    return toArr(ctx.copy[key]);
+  }
+
+  const MobileSections = {
+    status: (ctx) => {
+      const { D } = ctx.helpers;
+      const status = pickPageDict(ctx, 'statusBar');
+      return D.Containers.Div({ attrs: { class: 'mobile-status-bar' } }, [
+        D.Text.Span({}, [status.time || '9:41']),
+        D.Text.Span({}, [status.connectivity || '5G']),
+        D.Text.Span({}, [status.battery || '🔋'])
+      ]);
+    },
+
+    header: (ctx) => {
+      const { D, tw } = ctx.helpers;
+      const header = pickPageDict(ctx, 'header');
+      const showMenu = getMobilePages(ctx.copy).length > 1 || (toArr(ctx.copy.sideMenu?.items).length > 0);
+      const left = D.Containers.Div({ attrs: { class: tw`flex flex-col gap-1` } }, [
+        header.greeting ? D.Text.H3({ attrs: { class: tw`text-lg font-semibold` } }, [header.greeting]) : null,
+        header.subtitle ? D.Text.Span({ attrs: { class: tw`text-xs text-[var(--muted-foreground)]` } }, [header.subtitle]) : null,
+        header.pageTitle ? D.Text.Span({ attrs: { class: tw`text-xs text-[var(--muted-foreground)]` } }, [header.pageTitle]) : null
+      ].filter(Boolean));
+      const actions = [];
+      if (showMenu) {
+        actions.push(D.Forms.Button({
+          attrs: {
+            class: 'mobile-menu-toggle',
+            type: 'button',
+            gkey: 'mobile:menu:open',
+            'aria-label': 'Open menu'
+          }
+        }, ['☰']));
+      }
+      if (header.avatar) {
+        actions.push(D.Containers.Div({ attrs: { class: tw`grid h-10 w-10 place-items-center rounded-full bg-[color-mix(in oklab,var(--primary) 90%, transparent)] text-lg shadow-sm` } }, [header.avatar]));
+      }
+      return D.Containers.Div({ attrs: { class: tw`flex items-center justify-between` } }, [
+        left,
+        actions.length ? D.Containers.Div({ attrs: { class: tw`flex items-center gap-2` } }, actions) : null
+      ].filter(Boolean));
+    },
+
+    balance: (ctx) => {
+      const { D, UI, tw } = ctx.helpers;
+      const balance = pickPageDict(ctx, 'balance');
+      const chartCfg = ensureDict(balance.chart);
+      const chartHeight = chartCfg.height || 140;
+      const chart = chartCfg.data
+        ? UI.Chart.factory(chartCfg.type || 'line')({
+            data: chartCfg.data,
+            options: chartCfg.options,
+            height: chartHeight,
+            attrs: { 'data-chart-key': 'mobile:balance' },
+            description: 'منحنى الرصيد'
+          })
+        : null;
+      return D.Containers.Div({ attrs: { class: tw`mobile-balance-card flex flex-col gap-4` } }, [
+        D.Containers.Div({ attrs: { class: tw`flex flex-col gap-1` } }, [
+          balance.caption ? D.Text.Span({ attrs: { class: tw`text-xs text-white/70` } }, [balance.caption]) : null,
+          balance.amount ? D.Text.H3({ attrs: { class: tw`text-2xl font-bold` } }, [balance.amount]) : null,
+          balance.change ? D.Text.Span({ attrs: { class: tw`text-xs` } }, [balance.change]) : null
+        ].filter(Boolean)),
+        chart ? D.Containers.Div({ attrs: { class: tw`flex-1`, style: `min-height:${chartHeight}px;` } }, [chart]) : null
+      ].filter(Boolean));
+    },
+
+    quickActions: (ctx) => {
+      const { D, ensureDict, toArr, tw, cx } = ctx.helpers;
+      const actions = pickPageArray(ctx, 'quickActions');
+      if (!actions.length) return null;
+      const active = ctx.db?.ui?.activeAction;
+      const buttons = actions.map((entry, idx) => {
+        const action = ensureDict(entry);
+        const id = action.id || `action-${idx}`;
+        const isActive = active ? active === id : idx === 0;
+        const btnAttrs = {
+          class: cx('mobile-action-btn', isActive && 'ring-2 ring-[color-mix(in oklab,var(--primary) 65%, transparent)]'),
+          type: 'button',
+          gkey: action.gkey || 'mobile:actions:select',
+          'data-action-id': id
+        };
+        return D.Forms.Button({ attrs: btnAttrs }, [
+          action.icon ? D.Text.Span({ attrs: { class: tw`text-xl` } }, [action.icon]) : null,
+          action.label ? D.Text.Span({ attrs: { class: tw`text-xs font-medium` } }, [action.label]) : null
+        ].filter(Boolean));
+      });
+      return D.Containers.Div({ attrs: { class: 'mobile-quick-actions' } }, buttons);
+    },
+
+    highlights: (ctx) => {
+      const { D, ensureDict, toArr, tw } = ctx.helpers;
+      const highlights = pickPageArray(ctx, 'highlights');
+      if (!highlights.length) return null;
+      const cards = highlights.map((entry, idx) => {
+        const item = ensureDict(entry);
+        return D.Containers.Div({ attrs: { key: `highlight-${item.id || idx}`, class: 'mobile-highlight-card' } }, [
+          item.title ? D.Text.Span({ attrs: { class: tw`text-xs text-[var(--muted-foreground)]` } }, [item.title]) : null,
+          item.value ? D.Text.Strong({ attrs: { class: tw`text-lg font-semibold` } }, [item.value]) : null,
+          item.meta ? D.Text.Span({ attrs: { class: tw`text-xs text-[var(--muted-foreground)]` } }, [item.meta]) : null
+        ].filter(Boolean));
+      });
+      return D.Containers.Div({ attrs: { class: tw`grid gap-3 sm:grid-cols-2` } }, cards);
+    },
+
+    transactions: (ctx) => {
+      const { D, UI, ensureDict, toArr, tw } = ctx.helpers;
+      const section = pickPageDict(ctx, 'transactions');
+      const rows = toArr(section.items);
+      if (!rows.length) return null;
+      const entries = rows.map((entry, idx) => {
+        const item = ensureDict(entry);
+        const amountClass = item.type === 'in' ? tw`text-emerald-500 font-semibold` : tw`text-rose-500 font-semibold`;
+        return D.Containers.Div({ attrs: { class: 'mobile-transaction', key: `txn-${item.id || idx}` } }, [
+          D.Containers.Div({ attrs: { class: tw`flex flex-col gap-0.5` } }, [
+            item.name ? D.Text.Span({ attrs: { class: tw`text-sm font-medium` } }, [item.name]) : null,
+            item.time ? D.Text.Span({ attrs: { class: tw`text-xs text-[var(--muted-foreground)]` } }, [item.time]) : null
+          ].filter(Boolean)),
+          item.amount ? D.Text.Span({ attrs: { class: amountClass } }, [item.amount]) : null
+        ].filter(Boolean));
+      });
+      const footer = ensureDict(section.action);
+      const footerNode = footer.label
+        ? UI.Button({ attrs: { gkey: footer.gkey || 'mobile:transactions:all' }, variant: 'ghost', size: 'sm' }, [footer.label])
+        : null;
+      return D.Containers.Section({ attrs: { class: tw`flex flex-col gap-2` } }, [
+        section.title ? D.Text.H3({ attrs: { class: tw`text-base font-semibold` } }, [section.title]) : null,
+        ...entries,
+          footerNode ? D.Containers.Div({ attrs: { class: tw`pt-1` } }, [footerNode]) : null
+      ].filter(Boolean));
+    },
+
+    pageTabs: (ctx) => {
+      const { D, UI, tw } = ctx.helpers;
+      const pages = getMobilePages(ctx.copy);
+      if (!pages.length) return null;
+      const active = resolveActivePageId(ctx);
+      const items = pages.map((page, index) => {
+        const id = mobilePageKey(page, `page-${index}`);
+        return {
+          id,
+          label: page.label || page.title || `صفحة ${index + 1}`,
+          gkey: 'mobile:page:select'
+        };
+      });
+      return D.Containers.Div({ attrs: { class: 'mobile-page-tabs' } }, [
+        UI.Segmented({ items, activeId: active, attrs: { class: tw`w-full justify-between` } })
+      ]);
+    },
+
+    sideMenu: (ctx) => {
+      const { D, UI, ensureDict, toArr, tw, cx } = ctx.helpers;
+      const menu = ensureDict(ctx.copy.sideMenu);
+      const items = toArr(menu.items);
+      const preferences = toArr(menu.preferences);
+      const footer = ensureDict(menu.footer);
+      const open = !!(ctx.db && ctx.db.ui && ctx.db.ui.sideMenuOpen);
+      if (!open && !items.length && !preferences.length && !footer.label) {
+        return D.Containers.Div({ attrs: { class: tw`hidden` } });
+      }
+      const profile = ensureDict(menu.profile);
+      const activePage = resolveActivePageId(ctx);
+      const header = D.Containers.Div({ attrs: { class: 'mobile-menu-header' } }, [
+        profile.avatar ? D.Containers.Div({ attrs: { class: tw`grid h-12 w-12 place-items-center rounded-full bg-[color-mix(in oklab,var(--primary) 90%, transparent)] text-xl shadow-sm` } }, [profile.avatar]) : null,
+        D.Containers.Div({ attrs: { class: tw`flex flex-col` } }, [
+          profile.name ? D.Text.Strong({ attrs: { class: tw`text-sm` } }, [profile.name]) : null,
+          profile.email ? D.Text.Span({ attrs: { class: tw`text-xs text-[var(--muted-foreground)]` } }, [profile.email]) : null,
+          profile.badge ? UI.Badge({ text: profile.badge, variant: 'badge/ghost', attrs: { class: tw`text-[0.65rem]` } }) : null
+        ].filter(Boolean))
+      ].filter(Boolean));
+
+      const nav = items.length
+        ? D.Containers.Div({ attrs: { class: 'mobile-menu-items' } }, items.map((entry, index) => {
+            const item = ensureDict(entry);
+            const id = mobilePageKey(item, `page-${index}`);
+            const active = id === activePage;
+            return D.Forms.Button({
+              attrs: {
+                type: 'button',
+                class: cx('mobile-menu-item', active && 'is-active'),
+                gkey: 'mobile:page:select',
+                'data-page-id': id
+              }
+            }, [
+              D.Containers.Div({ attrs: { class: 'item-label' } }, [
+                item.icon ? D.Containers.Div({ attrs: { class: 'item-icon' } }, [item.icon]) : null,
+                item.label ? D.Text.Span({}, [item.label]) : null
+              ].filter(Boolean)),
+              active ? D.Text.Span({ attrs: { class: tw`text-xs` } }, ['›']) : null
+            ].filter(Boolean));
+          }))
+        : null;
+
+      const pref = preferences.length
+        ? D.Containers.Div({ attrs: { class: 'mobile-menu-preferences' } }, preferences.map((entry, index) => {
+            const prefItem = ensureDict(entry);
+            return D.Forms.Button({
+              attrs: {
+                type: 'button',
+                class: 'mobile-menu-pref',
+                gkey: prefItem.gkey || `mobile:pref:${index}`
+              }
+            }, [
+              D.Containers.Div({ attrs: { class: tw`flex items-center gap-2 text-sm` } }, [
+                prefItem.icon ? D.Text.Span({}, [prefItem.icon]) : null,
+                prefItem.label ? D.Text.Span({}, [prefItem.label]) : null
+              ].filter(Boolean)),
+              prefItem.action ? D.Text.Span({ attrs: { class: tw`text-xs text-[var(--muted-foreground)]` } }, [prefItem.action]) : null
+            ].filter(Boolean));
+          }))
+        : null;
+
+      const footerNode = footer.label
+        ? D.Containers.Div({ attrs: { class: 'mobile-menu-footer' } }, [
+            UI.Button({ attrs: { gkey: footer.gkey || 'mobile:menu:logout' }, variant: 'ghost', size: 'sm' }, [footer.label])
+          ])
+        : null;
+
+      const body = D.Containers.Div({ attrs: { class: 'mobile-menu-body' } }, [nav, pref, footerNode].filter(Boolean));
+
+      return UI.Drawer({
+        open,
+        side: menu.side || 'start',
+        closeGkey: 'mobile:menu:close',
+        header,
+        content: body
+      });
+    },
+
+    bottomNav: (ctx) => {
+      const { D, ensureDict, toArr, tw, cx } = ctx.helpers;
+      const config = ensureDict(ctx.copy.bottomNav);
+      const items = toArr(config.items);
+      if (!items.length) return null;
+      const active = resolveActivePageId(ctx);
+      const buttons = items.map((entry, index) => {
+        const item = ensureDict(entry);
+        const id = mobilePageKey(item, `page-${index}`);
+        const activeClass = id === active ? 'is-active' : '';
+        return D.Forms.Button({
+          attrs: {
+            type: 'button',
+            class: cx(activeClass),
+            gkey: 'mobile:page:select',
+            'data-page-id': id
+          }
+        }, [
+          item.icon ? D.Text.Span({ attrs: { class: 'icon' } }, [item.icon]) : null,
+          item.label ? D.Text.Span({ attrs: { class: tw`text-[0.7rem]` } }, [item.label]) : null
+        ].filter(Boolean));
+      });
+      return D.Containers.Div({ attrs: { class: 'mobile-bottom-nav' } }, buttons);
+    }
+  };
+
+  function LayoutMobileNeo(ctx) {
+    const { D, tw, cx } = ctx.helpers;
+    const status = ctx.render('status');
+    const header = ctx.render('header');
+    const pageTabs = ctx.render('pageTabs');
+    const balance = ctx.render('balance');
+    const quick = ctx.render('quickActions');
+    const highlights = ctx.render('highlights');
+    const transactions = ctx.render('transactions');
+    const bottomNav = ctx.render('bottomNav');
+    const sideMenu = ctx.render('sideMenu');
+
+    return D.Containers.Div({ attrs: { class: cx('mishkah-mobile', tw`w-full`) } }, [
+      D.Containers.Div({ attrs: { class: 'mishkah-mobile-shell' } }, [
+        D.Containers.Div({ attrs: { class: 'mishkah-mobile-content' } }, [
+          status,
+          header,
+          pageTabs,
+          balance,
+          quick,
+          highlights,
+          transactions,
+          bottomNav
+        ].filter(Boolean))
+      ]),
+      sideMenu
+    ]);
+  }
+
+  const MobileLayouts = { neo: LayoutMobileNeo };
+
   function LayoutAurora(ctx) {
     const { D, tw, cx } = ctx.helpers;
     const header = ctx.render('header');
@@ -590,6 +1612,109 @@
     }
   };
 
+  const DashboardOrders = {
+    'dashboard.filters.range': {
+      on: ['click'], gkeys: ['dashboard:filters:range'],
+      handler: (event, ctx) => {
+        const target = event.target.closest('[data-range-id]');
+        if (!target) return;
+        const id = target.getAttribute('data-range-id');
+        if (!id) return;
+        ctx.setState((state) => ({
+          ...state,
+          ui: { ...(state.ui || {}), activeRange: id }
+        }));
+        ctx.rebuild();
+        dispatchTemplateEvent('dashboard:filters:range', { id });
+      }
+    },
+    'dashboard.search': {
+      on: ['input', 'change'], gkeys: ['dashboard:search'],
+      handler: (event) => {
+        const value = event && event.target ? event.target.value : '';
+        dispatchTemplateEvent('dashboard:search', { value });
+      }
+    },
+    'dashboard.table.action': {
+      on: ['click'], gkeys: ['dashboard:table:action'],
+      handler: () => {
+        dispatchTemplateEvent('dashboard:table:action', {});
+      }
+    },
+    'dashboard.export': {
+      on: ['click'], gkeys: ['dashboard:export'],
+      handler: () => {
+        dispatchTemplateEvent('dashboard:export', {});
+      }
+    }
+  };
+
+  const MobileOrders = {
+    'mobile.actions.select': {
+      on: ['click'], gkeys: ['mobile:actions:select'],
+      handler: (event, ctx) => {
+        const btn = event.target.closest('[data-action-id]');
+        if (!btn) return;
+        const id = btn.getAttribute('data-action-id');
+        ctx.setState((state) => ({
+          ...state,
+          ui: { ...(state.ui || {}), activeAction: id }
+        }));
+        ctx.rebuild();
+        dispatchTemplateEvent('mobile:actions:select', { id });
+      }
+    },
+    'mobile.transactions.all': {
+      on: ['click'], gkeys: ['mobile:transactions:all'],
+      handler: () => {
+        dispatchTemplateEvent('mobile:transactions:all', {});
+      }
+    },
+    'mobile.menu.open': {
+      on: ['click'], gkeys: ['mobile:menu:open'],
+      handler: (_event, ctx) => {
+        ctx.setState((state) => ({
+          ...state,
+          ui: { ...(state.ui || {}), sideMenuOpen: true }
+        }));
+        ctx.rebuild();
+        dispatchTemplateEvent('mobile:menu:open', {});
+      }
+    },
+    'mobile.menu.close': {
+      on: ['click'], gkeys: ['mobile:menu:close'],
+      handler: (_event, ctx) => {
+        ctx.setState((state) => ({
+          ...state,
+          ui: { ...(state.ui || {}), sideMenuOpen: false }
+        }));
+        ctx.rebuild();
+        dispatchTemplateEvent('mobile:menu:close', {});
+      }
+    },
+    'mobile.page.select': {
+      on: ['click'], gkeys: ['mobile:page:select'],
+      handler: (event, ctx) => {
+        const target = event.target.closest('[data-page-id]');
+        if (!target) return;
+        const id = target.getAttribute('data-page-id');
+        if (!id) return;
+        ctx.setState((state) => ({
+          ...state,
+          ui: { ...(state.ui || {}), activePage: id, sideMenuOpen: false, activeAction: null }
+        }));
+        ctx.rebuild();
+        dispatchTemplateEvent('mobile:page:select', { id });
+      }
+    },
+    'mobile.menu.logout': {
+      on: ['click'], gkeys: ['mobile:menu:logout'],
+      handler: () => {
+        dispatchTemplateEvent('mobile:menu:logout', {});
+      }
+    }
+  };
+
   function toFactory(entry) {
     if (typeof entry === 'function') return entry;
     if (entry == null) return () => null;
@@ -608,11 +1733,12 @@
     return () => null;
   }
 
-  function normalizeSections(overrides) {
+  function normalizeSectionsWith(baseSections, overrides) {
     const defaults = {};
     const normalized = {};
-    Object.keys(DefaultSections).forEach((key) => {
-      const fn = toFactory(DefaultSections[key]);
+    const source = ensureDict(baseSections);
+    Object.keys(source).forEach((key) => {
+      const fn = toFactory(source[key]);
       defaults[key] = fn;
       normalized[key] = fn;
     });
@@ -623,9 +1749,23 @@
     return { normalized, defaults };
   }
 
+  function normalizeSections(overrides) {
+    return normalizeSectionsWith(DefaultSections, overrides);
+  }
+
   function resolveLayout(name) {
     const key = String(name || 'aurora').toLowerCase();
     return { key, render: Layouts[key] || Layouts.aurora };
+  }
+
+  function resolveDashboardLayout(name) {
+    const key = String(name || 'command').toLowerCase();
+    return { key, render: DashboardLayouts[key] || DashboardLayouts.command };
+  }
+
+  function resolveMobileLayout(name) {
+    const key = String(name || 'neo').toLowerCase();
+    return { key, render: MobileLayouts[key] || MobileLayouts.neo };
   }
 
   function buildDefaultDB(cfg) {
@@ -639,6 +1779,43 @@
       data: {},
       ui: { sidebarOpen: false }
     };
+  }
+
+  function buildDashboardDB(cfg, copy) {
+    const base = buildDefaultDB(cfg);
+    const ui = Object.assign({}, base.ui || {});
+    const filters = ensureDict(copy.filters);
+    const ranges = Array.isArray(filters.ranges) ? filters.ranges : [];
+    ui.activeRange = ui.activeRange || filters.activeRange || (ranges[0] && (ranges[0].id || ranges[0].value)) || '7d';
+    base.ui = ui;
+    return base;
+  }
+
+  function buildMobileDB(cfg, copy) {
+    const base = buildDefaultDB(cfg);
+    const ui = Object.assign({}, base.ui || {});
+    const pages = Array.isArray(copy.pages) ? copy.pages.filter(Boolean) : [];
+    if (pages.length) {
+      const firstId = mobilePageKey(ensureDict(pages[0]), 'page-0');
+      ui.activePage = ui.activePage || firstId;
+      const resolved = pages.find((page, index) => mobilePageKey(ensureDict(page), `page-${index}`) === ui.activePage) || ensureDict(pages[0]);
+      const actions = Array.isArray(resolved.quickActions) ? resolved.quickActions.filter(Boolean) : [];
+      if (!ui.activeAction && actions.length) {
+        const firstAction = ensureDict(actions[0]);
+        ui.activeAction = firstAction.id || `action-0`;
+      }
+    } else {
+      const actions = Array.isArray(copy.quickActions) ? copy.quickActions.filter(Boolean) : [];
+      if (!ui.activeAction && actions.length) {
+        const firstAction = ensureDict(actions[0]);
+        ui.activeAction = firstAction.id || 'action-0';
+      }
+    }
+    if (typeof ui.sideMenuOpen !== 'boolean') {
+      ui.sideMenuOpen = false;
+    }
+    base.ui = ui;
+    return base;
   }
 
   function buildRenderer(cfg, copy, sections, defaults) {
@@ -669,6 +1846,58 @@
     };
   }
 
+  function buildDashboardRenderer(cfg, copy, sections, defaults) {
+    const { key, render } = resolveDashboardLayout(cfg.layout);
+    return function DashboardBody(db) {
+      const context = {
+        db,
+        cfg,
+        copy,
+        layout: key,
+        sections,
+        defaults,
+        helpers: helperBag,
+        render: null
+      };
+      context.render = function renderSlot(name, fallback) {
+        const factory = sections[name];
+        let node = null;
+        if (typeof factory === 'function') node = factory(context);
+        if (!node && typeof fallback === 'function') {
+          return fallback(context);
+        }
+        return node || null;
+      };
+      return render(context);
+    };
+  }
+
+  function buildMobileRenderer(cfg, copy, sections, defaults) {
+    const { key, render } = resolveMobileLayout(cfg.layout);
+    return function MobileBody(db) {
+      const context = {
+        db,
+        cfg,
+        copy,
+        layout: key,
+        sections,
+        defaults,
+        helpers: helperBag,
+        render: null
+      };
+      context.render = function renderSlot(name, fallback) {
+        const factory = sections[name];
+        let node = null;
+        if (typeof factory === 'function') node = factory(context);
+        if (!node && typeof fallback === 'function') {
+          return fallback(context);
+        }
+        return node || null;
+      };
+      return render(context);
+    };
+  }
+
   function createTemplateApp(options) {
     const cfg = Object.assign({}, DEFAULT_OPTIONS, ensureDict(options));
     const copy = mergeDeep(DEFAULT_COPY, ensureDict(cfg.copy));
@@ -686,6 +1915,9 @@
     const auto = U.twcss.auto(database, app, { pageScaffold: cfg.scaffold !== false, fonts: cfg.fonts });
     app.setOrders(Object.assign({}, UI.orders, auto.orders, orders));
     app.mount(cfg.mount || '#app');
+    if (UI.Chart && typeof UI.Chart.bindApp === 'function') {
+      UI.Chart.bindApp(app, cfg.mount || '#app');
+    }
     return app;
   }
 
@@ -697,7 +1929,89 @@
     return buildRenderer(cfg, copy, sections, defaults);
   }
 
+  function createDashboardApp(options) {
+    const cfg = Object.assign({}, DASHBOARD_DEFAULT_OPTIONS, ensureDict(options));
+    const copy = mergeDeep(DEFAULT_DASHBOARD_COPY, ensureDict(cfg.copy));
+    const { normalized: sections, defaults } = normalizeSectionsWith(DashboardSections, cfg.sections);
+    const renderer = buildDashboardRenderer(cfg, copy, sections, defaults);
+    injectBaseStyles();
+
+    const database = isObj(cfg.database)
+      ? mergeDeep(buildDashboardDB(cfg, copy), cfg.database)
+      : buildDashboardDB(cfg, copy);
+
+    M.app.setBody(renderer);
+    const orders = Object.assign({}, DashboardOrders, ensureDict(cfg.orders));
+    const app = M.app.createApp(database, orders);
+    const auto = U.twcss.auto(database, app, { pageScaffold: cfg.scaffold !== false, fonts: cfg.fonts });
+    app.setOrders(Object.assign({}, UI.orders, auto.orders, orders));
+    app.mount(cfg.mount || '#app');
+    if (UI.Chart && typeof UI.Chart.bindApp === 'function') {
+      UI.Chart.bindApp(app, cfg.mount || '#app');
+    }
+    return app;
+  }
+
+  function createMobileApp(options) {
+    const cfg = Object.assign({}, MOBILE_DEFAULT_OPTIONS, ensureDict(options));
+    const copy = mergeDeep(DEFAULT_MOBILE_COPY, ensureDict(cfg.copy));
+    const { normalized: sections, defaults } = normalizeSectionsWith(MobileSections, cfg.sections);
+    const renderer = buildMobileRenderer(cfg, copy, sections, defaults);
+    injectBaseStyles();
+
+    const database = isObj(cfg.database)
+      ? mergeDeep(buildMobileDB(cfg, copy), cfg.database)
+      : buildMobileDB(cfg, copy);
+
+    M.app.setBody(renderer);
+    const orders = Object.assign({}, MobileOrders, ensureDict(cfg.orders));
+    const app = M.app.createApp(database, orders);
+    const auto = U.twcss.auto(database, app, { pageScaffold: cfg.scaffold !== false, fonts: cfg.fonts });
+    app.setOrders(Object.assign({}, UI.orders, auto.orders, orders));
+    app.mount(cfg.mount || '#app');
+    if (UI.Chart && typeof UI.Chart.bindApp === 'function') {
+      UI.Chart.bindApp(app, cfg.mount || '#app');
+    }
+    return app;
+  }
+
+  function DashboardPage(config) {
+    const cfg = Object.assign({}, DASHBOARD_DEFAULT_OPTIONS, ensureDict(config));
+    const copy = mergeDeep(DEFAULT_DASHBOARD_COPY, ensureDict(cfg.copy));
+    const { normalized: sections, defaults } = normalizeSectionsWith(DashboardSections, cfg.sections);
+    injectBaseStyles();
+    return buildDashboardRenderer(cfg, copy, sections, defaults);
+  }
+
+  function MobilePage(config) {
+    const cfg = Object.assign({}, MOBILE_DEFAULT_OPTIONS, ensureDict(config));
+    const copy = mergeDeep(DEFAULT_MOBILE_COPY, ensureDict(cfg.copy));
+    const { normalized: sections, defaults } = normalizeSectionsWith(MobileSections, cfg.sections);
+    injectBaseStyles();
+    return buildMobileRenderer(cfg, copy, sections, defaults);
+  }
+
   injectBaseStyles();
+
+  const DashboardAPI = {
+    defaults: DEFAULT_DASHBOARD_COPY,
+    sections: DashboardSections,
+    orders: DashboardOrders,
+    create: createDashboardApp,
+    AppPage: DashboardPage,
+    buildDB: (cfg, copy) => buildDashboardDB(cfg || {}, copy || DEFAULT_DASHBOARD_COPY)
+  };
+
+  const MobileAPI = {
+    defaults: DEFAULT_MOBILE_COPY,
+    sections: MobileSections,
+    orders: MobileOrders,
+    create: createMobileApp,
+    AppPage: MobilePage,
+    buildDB: (cfg, copy) => buildMobileDB(cfg || {}, copy || DEFAULT_MOBILE_COPY)
+  };
+
+  const prevCatalog = (M.Templates && M.Templates.catalog) || {};
 
   M.Templates = Object.assign(M.Templates || {}, {
     layouts: Layouts,
@@ -707,7 +2021,20 @@
     create: createTemplateApp,
     bootstrap: createTemplateApp,
     AppPage,
-    buildDB: buildDefaultDB
+    buildDB: buildDefaultDB,
+    dashboard: DashboardAPI,
+    mobile: MobileAPI,
+    catalog: Object.assign({}, prevCatalog, {
+      marketing: {
+        create: createTemplateApp,
+        AppPage,
+        defaults: DEFAULT_COPY,
+        sections: DefaultSections,
+        orders: TemplateOrders
+      },
+      dashboard: DashboardAPI,
+      mobile: MobileAPI
+    })
   });
 
 })(typeof window !== 'undefined' ? window : this);

--- a/mobile.html
+++ b/mobile.html
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <title>تجربة التطبيق المصرفي — عرض قالب مشكاة</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <script src="./mishkah-utils.js"></script>
+  <script src="./mishkah.core.js"></script>
+  <script src="./mishkah-ui.js"></script>
+  <script src="./mishkah.templates.js"></script>
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    const { Chart } = Mishkah.UI;
+
+    const mobileCopy = {
+      statusBar: { time: '10:24', connectivity: '5G', battery: '🔋 76%' },
+      header: { greeting: 'أهلاً، وليد', subtitle: 'إجمالي الرصيد المتاح', avatar: '💳', pageTitle: 'حساباتي' },
+      balance: {
+        amount: '52,430 ر.س',
+        change: '+2,150 ر.س هذا الشهر',
+        caption: 'تم التحديث قبل دقيقة',
+        chart: {
+          type: 'line',
+          height: 140,
+          data: {
+            labels: ['أ', 'ب', 'ج', 'د', 'هـ', 'و', 'ز'],
+            datasets: [
+              {
+                label: 'الرصيد',
+                data: [41, 43, 44, 46, 48, 50, 52],
+                fill: true,
+                borderColor: 'rgba(34,197,94,1)',
+                backgroundColor: 'rgba(34,197,94,0.24)',
+                pointRadius: 0
+              }
+            ]
+          },
+          options: {
+            plugins: { legend: { display: false } },
+            scales: { x: { display: false }, y: { display: false } }
+          }
+        }
+      },
+      quickActions: [
+        { id: 'transfer', label: 'تحويل', icon: '↗️' },
+        { id: 'split', label: 'تقسيم فاتورة', icon: '🤝' },
+        { id: 'topup', label: 'شحن رصيد', icon: '⚡️' }
+      ],
+      highlights: [
+        { id: 'budget', title: 'موازنة السفر', value: '65% مستخدم', meta: '3,500 ر.س متبقي' },
+        { id: 'goals', title: 'ادخار العقار', value: '124,000 ر.س', meta: '+2,000 ر.س هذا الربع' }
+      ],
+      transactions: {
+        title: 'آخر الحركات',
+        items: [
+          { id: 'coffee', name: 'مقهى المساء', time: 'اليوم • 08:10', amount: '-18 ر.س', type: 'out' },
+          { id: 'salary', name: 'راتب الشركة', time: 'أمس • 18:30', amount: '+12,500 ر.س', type: 'in' },
+          { id: 'rent', name: 'دفعة إيجار', time: 'أمس • 08:00', amount: '-4,200 ر.س', type: 'out' }
+        ],
+        action: { label: 'عرض السجل الكامل', gkey: 'mobile:transactions:all' }
+      },
+      pages: [
+        {
+          id: 'overview',
+          label: 'الرئيسية',
+          header: { greeting: 'أهلاً، وليد', subtitle: 'إجمالي الرصيد المتاح', avatar: '💳', pageTitle: 'الحسابات النشطة' },
+          balance: {
+            amount: '52,430 ر.س',
+            change: '+2,150 ر.س هذا الشهر',
+            caption: 'تمت المزامنة قبل دقيقة',
+            chart: {
+              type: 'line',
+              height: 140,
+              data: {
+                labels: ['أ', 'ب', 'ج', 'د', 'هـ', 'و', 'ز'],
+                datasets: [
+                  {
+                    label: 'الرصيد التراكمي',
+                    data: [41, 43, 44, 46, 48, 50, 52],
+                    fill: true,
+                    borderColor: 'rgba(59,130,246,1)',
+                    backgroundColor: 'rgba(59,130,246,0.24)',
+                    pointRadius: 0
+                  }
+                ]
+              },
+              options: {
+                plugins: { legend: { display: false } },
+                scales: { x: { display: false }, y: { display: false } }
+              }
+            }
+          },
+          quickActions: [
+            { id: 'transfer', label: 'تحويل سريع', icon: '↗️' },
+            { id: 'split', label: 'تقسيم فاتورة', icon: '🤝' },
+            { id: 'saving', label: 'إيداع ادخار', icon: '💠' }
+          ],
+          highlights: [
+            { id: 'budget', title: 'موازنة السفر', value: '65% مستخدم', meta: '3,500 ر.س متبقي' },
+            { id: 'goals', title: 'هدف العقار', value: '124,000 ر.س', meta: '+2,000 ر.س هذا الربع' }
+          ],
+          transactions: {
+            title: 'آخر الحركات',
+            items: [
+              { id: 'coffee', name: 'مقهى المساء', time: 'اليوم • 08:10', amount: '-18 ر.س', type: 'out' },
+              { id: 'salary', name: 'راتب الشركة', time: 'أمس • 18:30', amount: '+12,500 ر.س', type: 'in' },
+              { id: 'rent', name: 'دفعة إيجار', time: 'أمس • 08:00', amount: '-4,200 ر.س', type: 'out' }
+            ],
+            action: { label: 'عرض السجل الكامل', gkey: 'mobile:transactions:all' }
+          }
+        },
+        {
+          id: 'cards',
+          label: 'البطاقات',
+          header: { greeting: 'البطاقات الذكية', subtitle: 'إدارة البطاقات الرقمية', avatar: '💠', pageTitle: 'إدارة البطاقات' },
+          quickActions: [
+            { id: 'freeze', label: 'إيقاف بطاقة', icon: '🛑' },
+            { id: 'limit', label: 'تعديل الحدود', icon: '🎯' },
+            { id: 'issue', label: 'إصدار بطاقة', icon: '✨' }
+          ],
+          highlights: [
+            { id: 'visa', title: 'بطاقة Visa', value: '12,500 ر.س حد متاح', meta: 'آخر استخدام قبل 12 ساعة' },
+            { id: 'digital', title: 'البطاقة الرقمية', value: '4,300 ر.س حد متاح', meta: 'استخدام أسبوعي 3 مرات' }
+          ],
+          transactions: {
+            title: 'نشاط البطاقات',
+            items: [
+              { id: 'flight', name: 'حجز طيران', time: 'اليوم • 07:10', amount: '-1,240 ر.س', type: 'out' },
+              { id: 'refund', name: 'استرداد متجر', time: 'أمس • 19:40', amount: '+320 ر.س', type: 'in' },
+              { id: 'subscription', name: 'اشتراك منصة', time: 'أمس • 11:05', amount: '-45 ر.س', type: 'out' }
+            ],
+            action: { label: 'إدارة البطاقات', gkey: 'mobile:cards:manage' }
+          }
+        },
+        {
+          id: 'insights',
+          label: 'Insights',
+          header: { greeting: 'Financial Insights', subtitle: 'Global spend overview', avatar: '🌍', pageTitle: 'Analytics' },
+          balance: {
+            amount: '$13,480',
+            change: 'YoY growth 18%',
+            caption: 'Last synced 2 minutes ago',
+            chart: {
+              type: 'bar',
+              height: 160,
+              data: {
+                labels: ['Transport', 'Dining', 'Shopping', 'Travel'],
+                datasets: [
+                  {
+                    label: 'Spending',
+                    data: [620, 540, 460, 380],
+                    borderRadius: 14,
+                    backgroundColor: ['rgba(56,189,248,0.75)', 'rgba(249,115,22,0.78)', 'rgba(129,140,248,0.82)', 'rgba(16,185,129,0.82)']
+                  }
+                ]
+              },
+              options: {
+                plugins: { legend: { display: false } },
+                scales: {
+                  y: {
+                    beginAtZero: true,
+                    ticks: { callback: Chart.formatters.currency('USD', { locale: 'en-US', digits: 0 }) }
+                  }
+                }
+              }
+            }
+          },
+          highlights: [
+            { id: 'trend', title: 'Spending trend', value: '-8% vs last month', meta: 'Keep up the pace' },
+            { id: 'saving', title: 'Saving goal', value: '62% completed', meta: '4 months left to target' }
+          ],
+          transactions: {
+            title: 'Upcoming reminders',
+            items: [
+              { id: 'rent', name: 'Rent payment', time: 'Due in 3 days', amount: '-$1,120', type: 'out' },
+              { id: 'invest', name: 'Investment plan', time: 'Due next week', amount: '-$600', type: 'out' },
+              { id: 'bonus', name: 'Annual bonus', time: 'Next month', amount: '+$2,400', type: 'in' }
+            ],
+            action: { label: 'Manage reminders', gkey: 'mobile:insights:reminders' }
+          }
+        }
+      ],
+      sideMenu: {
+        profile: { name: 'وليد ناصر', email: 'waleed@mishkah.app', avatar: '🪪', badge: 'Gold' },
+        items: [
+          { id: 'overview', icon: '🏠', label: 'لوحة الحساب' },
+          { id: 'cards', icon: '💳', label: 'البطاقات الذكية' },
+          { id: 'insights', icon: '📊', label: 'التحليلات' }
+        ],
+        preferences: [
+          { id: 'theme', icon: '🌓', label: 'تبديل الثيم', gkey: 'ui:theme-toggle' },
+          { id: 'lang-ar', icon: '🇸🇦', label: 'العربية', gkey: 'ui:lang-ar' },
+          { id: 'lang-en', icon: '🇬🇧', label: 'English', gkey: 'ui:lang-en' }
+        ],
+        footer: { label: 'تسجيل الخروج', gkey: 'mobile:menu:logout' }
+      },
+      bottomNav: {
+        items: [
+          { id: 'overview', label: 'الرئيسية', icon: '🏠' },
+          { id: 'cards', label: 'البطاقات', icon: '💳' },
+          { id: 'insights', label: 'Insights', icon: '📈' }
+        ]
+      }
+    };
+
+    const demoOrders = {
+      'demo.mobile.cards.manage': {
+        on: ['click'], gkeys: ['mobile:cards:manage'],
+        handler: () => {
+          window.dispatchEvent(new CustomEvent('mishkah:template', { detail: { type: 'mobile:cards:manage', payload: {} } }));
+        }
+      },
+      'demo.mobile.insights.reminders': {
+        on: ['click'], gkeys: ['mobile:insights:reminders'],
+        handler: () => {
+          window.dispatchEvent(new CustomEvent('mishkah:template', { detail: { type: 'mobile:insights:reminders', payload: {} } }));
+        }
+      }
+    };
+
+    Mishkah.Templates.mobile.create({
+      mount: '#app',
+      theme: 'dark',
+      lang: 'ar',
+      copy: mobileCopy,
+      orders: demoOrders
+    });
+
+    window.addEventListener('mishkah:template', (event) => {
+      const detail = event.detail || {};
+      const { type, payload } = detail;
+      if (!type) return;
+      if (type === 'mobile:actions:select') {
+        console.info('🟢 تم اختيار إجراء سريع:', payload);
+      } else if (type === 'mobile:transactions:all') {
+        window.alert('📚 عرض سجل الحركات الكامل');
+      } else if (type === 'mobile:menu:open') {
+        console.debug('📂 فتح قائمة التنقل الجانبية');
+      } else if (type === 'mobile:menu:close') {
+        console.debug('📂 إغلاق قائمة التنقل');
+      } else if (type === 'mobile:page:select') {
+        console.info('📱 تم الانتقال إلى صفحة:', payload);
+      } else if (type === 'mobile:cards:manage') {
+        window.alert('💳 فتح إعدادات إدارة البطاقات');
+      } else if (type === 'mobile:insights:reminders') {
+        window.alert('⏰ عرض تذكيرات التحليلات القادمة');
+      } else if (type === 'mobile:menu:logout') {
+        window.alert('👋 تم تسجيل الخروج من الجلسة التجريبية');
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- sanitize chart payloads and expose reusable formatters in `mishkah-ui.js` to prevent cloning failures and simplify formatter reuse
- update the dashboard showcase to rely on the new chart formatters for percentage axes
- extend the mobile template with side navigation, page tabs, and bottom navigation plus corresponding CSS and orders, and refresh `mobile.html` to demonstrate multi-page, multi-language usage

## Testing
- not run (static showcase files)


------
https://chatgpt.com/codex/tasks/task_e_68e40d6499588333af2e5391206a838b