### PR TITLE
Propagate classification state through ERD library flows

### DIFF
--- a/erd.html
+++ b/erd.html
@@ -167,6 +167,21 @@
       'toolbar.zoom.out.title':{ ar:'تصغير', en:'Zoom out' },
       'toolbar.zoom.reset.title':{ ar:'إعادة الحجم', en:'Reset zoom' },
       'toolbar.zoom.in.title':{ ar:'تكبير', en:'Zoom in' },
+      'classification.title':{ ar:'sche_Tree', en:'sche_Tree' },
+      'classification.addRow':{ ar:'إضافة صف', en:'Add row' },
+      'classification.save':{ ar:'حفظ التصنيف', en:'Save classification' },
+      'classification.bulk':{ ar:'ترميز الشجرة', en:'Encode tree' },
+      'classification.code':{ ar:'الكود', en:'Code' },
+      'classification.name':{ ar:'الاسم', en:'Name' },
+      'classification.parent':{ ar:'الأب', en:'Parent' },
+      'classification.empty':{ ar:'لم يتم تعريف أي فئات بعد.', en:'No classes defined yet.' },
+      'classification.leaf.only':{ ar:'يرجى اختيار كود نهائي من الشجرة.', en:'Please choose a leaf code from the tree.' },
+      'modal.classification.title':{ ar:'إدارة ترميز الشجرة', en:'Manage tree encoding' },
+      'modal.classification.description':{ ar:'حرر قائمة الفئات بصيغة JSON (code، name، parent).', en:'Edit the class list as JSON (code, name, parent).' },
+      'modal.classification.placeholder':{ ar:'[{"code":"01","name":"Root","parent":null}]', en:'[{"code":"01","name":"Root","parent":null}]' },
+      'modal.classification.apply':{ ar:'تطبيق', en:'Apply' },
+      'modal.table.class.placeholder':{ ar:'اختر الفئة', en:'Select class' },
+      'modal.table.class.label':{ ar:'الفئة (Class)', en:'Class' },
       'modal.import.title':{ ar:'استيراد مخطط JSON', en:'Import JSON diagram' },
       'modal.import.description':{ ar:'ألصق بيانات المخطط أو استبدل مخططًا موجودًا.', en:'Paste the diagram data or replace an existing diagram.' },
       'modal.import.name.placeholder':{ ar:'المعرف الفريد للمخطط (name)', en:'Unique diagram identifier (name)' },
@@ -622,58 +637,136 @@
       return fallback;
     }
 
-    function pointKey(point){
-      if(!point) return '0:0';
-      const px = Math.round(Number(point.x) || 0);
-      const py = Math.round(Number(point.y) || 0);
-      return `${px}:${py}`;
+    function createRectIndex({ cellWidth = AUTO_LAYOUT_COLUMN_GAP, cellHeight = AUTO_LAYOUT_ROW_GAP, padding = 32 } = {}){
+      const buckets = new Map();
+      const padX = Math.max(0, Number(padding) || 0);
+      const padY = padX;
+      function expandedRect(rect){
+        return {
+          x: rect.x - padX / 2,
+          y: rect.y - padY / 2,
+          width: rect.width + padX,
+          height: rect.height + padY,
+        };
+      }
+      function cellKey(col, row){
+        return `${col}:${row}`;
+      }
+      function eachCell(rect, callback){
+        const area = expandedRect(rect);
+        const minCol = Math.floor(area.x / cellWidth);
+        const maxCol = Math.floor((area.x + area.width) / cellWidth);
+        const minRow = Math.floor(area.y / cellHeight);
+        const maxRow = Math.floor((area.y + area.height) / cellHeight);
+        for(let row = minRow; row <= maxRow; row += 1){
+          for(let col = minCol; col <= maxCol; col += 1){
+            callback(col, row, cellKey(col, row));
+          }
+        }
+      }
+      return {
+        insert(rect){
+          eachCell(rect, (_col, _row, key)=>{
+            if(!buckets.has(key)) buckets.set(key, []);
+            buckets.get(key).push(rect);
+          });
+        },
+        collides(rect){
+          let hit = false;
+          eachCell(rect, (_col, _row, key)=>{
+            if(hit) return;
+            const list = buckets.get(key);
+            if(!list) return;
+            for(let idx = 0; idx < list.length; idx += 1){
+              if(rectsOverlap(rect, list[idx])){
+                hit = true;
+                break;
+              }
+            }
+          });
+          return hit;
+        }
+      };
     }
 
-    function claimPoint(preferred, fallback, used){
+    function rectsOverlap(a, b){
+      if(!a || !b) return false;
+      const aRight = a.x + a.width;
+      const bRight = b.x + b.width;
+      const aBottom = a.y + a.height;
+      const bBottom = b.y + b.height;
+      if(aRight <= b.x) return false;
+      if(bRight <= a.x) return false;
+      if(aBottom <= b.y) return false;
+      if(bBottom <= a.y) return false;
+      return true;
+    }
+
+    function claimRect(preferred, fallback, index, options = {}){
+      const rectIndex = index || createRectIndex({ padding: options.padding });
+      const width = Math.max(1, Number(options.width) || TABLE_WIDTH);
+      const height = Math.max(1, Number(options.height) || AUTO_LAYOUT_ROW_GAP);
+      const stepX = Math.max(16, Number(options.stepX) || AUTO_LAYOUT_COLUMN_GAP);
+      const stepY = Math.max(16, Number(options.stepY) || AUTO_LAYOUT_ROW_GAP);
       const safeFallback = fallback || { x: AUTO_LAYOUT_ORIGIN_X, y: AUTO_LAYOUT_ORIGIN_Y };
-      let candidate = normalisePoint(preferred, safeFallback);
-      let key = pointKey(candidate);
-      if(!used.has(key)){
-        used.add(key);
-        return candidate;
-      }
       const origin = normalisePoint(safeFallback, safeFallback);
-      const offsets = [
-        { x: 0, y: 0 },
-        { x: AUTO_LAYOUT_COLUMN_GAP * 0.5, y: 0 },
-        { x: -AUTO_LAYOUT_COLUMN_GAP * 0.5, y: 0 },
-        { x: 0, y: AUTO_LAYOUT_ROW_GAP * 0.5 },
-        { x: 0, y: -AUTO_LAYOUT_ROW_GAP * 0.5 },
-      ];
-      for(let idx = 0; idx < offsets.length; idx += 1){
-        const offset = offsets[idx];
-        candidate = { x: origin.x + offset.x, y: origin.y + offset.y };
-        key = pointKey(candidate);
-        if(!used.has(key)){
-          used.add(key);
+
+      function rounded(point){
+        return { x: Math.round(point.x), y: Math.round(point.y) };
+      }
+
+      function makeRect(point){
+        const roundedPoint = rounded(point);
+        return { x: roundedPoint.x, y: roundedPoint.y, width, height };
+      }
+
+      function tryPlace(point){
+        const rect = makeRect(point);
+        if(rectIndex.collides(rect)) return false;
+        rectIndex.insert(rect);
+        return true;
+      }
+
+      const initial = normalisePoint(preferred, origin);
+      if(tryPlace(initial)){
+        return rounded(initial);
+      }
+
+      const seen = new Set();
+      const candidates = [];
+      const addCandidate = (point)=>{
+        const roundedPoint = rounded(point);
+        const key = `${roundedPoint.x}:${roundedPoint.y}`;
+        if(seen.has(key)) return;
+        seen.add(key);
+        candidates.push(roundedPoint);
+      };
+
+      addCandidate(initial);
+      addCandidate(origin);
+
+      const maxRadius = 48;
+      for(let radius = 1; radius <= maxRadius; radius += 1){
+        const offsetX = stepX * radius;
+        const offsetY = stepY * radius;
+        addCandidate({ x: origin.x + offsetX, y: origin.y });
+        addCandidate({ x: origin.x, y: origin.y + offsetY });
+        addCandidate({ x: origin.x - offsetX, y: origin.y });
+        addCandidate({ x: origin.x, y: origin.y - offsetY });
+        addCandidate({ x: origin.x + offsetX, y: origin.y + offsetY });
+        addCandidate({ x: origin.x - offsetX, y: origin.y + offsetY });
+        addCandidate({ x: origin.x + offsetX, y: origin.y - offsetY });
+        addCandidate({ x: origin.x - offsetX, y: origin.y - offsetY });
+      }
+
+      for(let idx = 0; idx < candidates.length; idx += 1){
+        const candidate = candidates[idx];
+        if(tryPlace(candidate)){
           return candidate;
         }
       }
-      let radius = 1;
-      while(radius <= 24){
-        const variations = [
-          { x: origin.x + radius * 60, y: origin.y + radius * 40 },
-          { x: origin.x - radius * 60, y: origin.y + radius * 40 },
-          { x: origin.x + radius * 60, y: origin.y - radius * 40 },
-          { x: origin.x - radius * 60, y: origin.y - radius * 40 },
-        ];
-        for(let attempt = 0; attempt < variations.length; attempt += 1){
-          candidate = variations[attempt];
-          key = pointKey(candidate);
-          if(!used.has(key)){
-            used.add(key);
-            return candidate;
-          }
-        }
-        radius += 1;
-      }
-      used.add(key);
-      return candidate;
+
+      return rounded(initial);
     }
 
     function normalisePoint(point, fallback){
@@ -681,6 +774,104 @@
         return { x: Number(point.x), y: Number(point.y) };
       }
       return { x: fallback.x, y: fallback.y };
+    }
+
+    function normaliseClasses(input){
+      if(!Array.isArray(input)) return [];
+      const seen = new Set();
+      const out = [];
+      input.forEach(item => {
+        if(!item) return;
+        const rawCode = item.code != null ? String(item.code).trim() : '';
+        const code = rawCode.replace(/\s+/g, '');
+        if(!code || code.length % 2 !== 0) return;
+        const name = item.name != null ? String(item.name).trim() : '';
+        const parentRaw = item.parent != null && item.parent !== '' ? String(item.parent).trim() : null;
+        const parent = parentRaw ? parentRaw.replace(/\s+/g, '') : null;
+        if(parent && parent.length % 2 !== 0) return;
+        if(code === parent) return;
+        if(seen.has(code)) return;
+        seen.add(code);
+        out.push({ code, name, parent });
+      });
+      out.sort((a, b) => a.code.localeCompare(b.code, undefined, { numeric:true }));
+      return out;
+    }
+
+    function classesByParent(classes){
+      const map = new Map();
+      classes.forEach(item => {
+        if(!item || !item.code) return;
+        const parent = item.parent || null;
+        if(!map.has(parent)) map.set(parent, []);
+        map.get(parent).push(item);
+      });
+      return map;
+    }
+
+    function computeClassLeaves(classes){
+      const byParent = classesByParent(classes);
+      return classes.filter(item => {
+        const children = byParent.get(item.code);
+        return !children || children.length === 0;
+      });
+    }
+
+    function classDepth(code){
+      if(!code) return 0;
+      return Math.max(0, Math.floor(code.length / 2));
+    }
+
+    function commitClasses(ctx, nextClasses, options = {}){
+      const normalized = normaliseClasses(nextClasses);
+      let nextState = null;
+      ctx.setState(s => {
+        const now = Date.now();
+        const classificationForm = s.ui?.form?.classification || {};
+        const tableForm = s.ui?.form?.table || {};
+        const leafCodes = new Set(computeClassLeaves(normalized).map(item => item.code));
+        const tableClassCode = tableForm.classCode && leafCodes.has(tableForm.classCode)
+          ? tableForm.classCode
+          : '';
+        const record = {
+          id: s.data.schemaId,
+          name: s.data.schemaMeta?.name || '',
+          title: s.data.schemaMeta?.title || '',
+          description: s.data.schemaMeta?.description || '',
+          schema: s.data.schema,
+          layout: s.data.layout,
+          canvas: s.data.canvas,
+          classes: normalized,
+          createdAt: s.data.schemaCreatedAt,
+          updatedAt: now
+        };
+        const rows = normalized.map(item => ({ ...item }));
+        const draft = {
+          ...s,
+          data:{
+            ...s.data,
+            classes: normalized,
+            schemaUpdatedAt: now,
+            library:{ ...(s.data.library || {}), items: mergeLibraryItems(s.data.library?.items || [], record) }
+          },
+          ui:{
+            ...(s.ui || {}),
+            modals:{ ...(s.ui?.modals || {}), classification: options.closeModal ? false : (s.ui?.modals?.classification || false) },
+            form:{
+              ...(s.ui?.form || {}),
+              classification:{ rows, bulkText: normalized.length ? JSON.stringify(normalized, null, 2) : '' },
+              table:{ ...(tableForm || {}), classCode: tableClassCode }
+            }
+          }
+        };
+        nextState = draft;
+        return draft;
+      });
+      ctx.rebuild();
+      if(nextState){
+        schedulePersist(recordFromState(nextState));
+      }
+      return nextState;
     }
 
     function computeLayoutBounds(nodes){
@@ -2217,6 +2408,7 @@
           schema: s.data.schema,
           layout,
           canvas: s.data.canvas,
+          classes: s.data.classes || [],
           createdAt: s.data.schemaCreatedAt,
           updatedAt: now,
         };
@@ -2293,6 +2485,7 @@
           schema: schemaJSON,
           layout: s.data.layout,
           canvas: s.data.canvas,
+          classes: s.data.classes || [],
           createdAt: s.data.schemaCreatedAt,
           updatedAt: now,
         };
@@ -2439,6 +2632,7 @@
           schema: registry.toJSON(),
           layout,
           canvas:{ zoom:1, mode:'auto' },
+          classes:[],
           createdAt: now,
           updatedAt: now
         };
@@ -2453,9 +2647,10 @@
         const schema = clone(input.schema || { tables: [] });
         const layout = clone(input.layout || {});
         const canvas = normaliseCanvas(clone(input.canvas || {}));
+        const classes = normaliseClasses(clone(input.classes || []));
         const createdAt = input.createdAt || now;
         const updatedAt = bumpUpdatedAt ? now : (input.updatedAt || now);
-        return { id, name, title, description, schema, layout, canvas, createdAt, updatedAt };
+        return { id, name, title, description, schema, layout, canvas, classes, createdAt, updatedAt };
       }
 
       async function ready(){
@@ -2528,6 +2723,7 @@
           schema: new Schema.Registry().toJSON(),
           layout:{},
           canvas:{ zoom:1, mode:'auto' },
+          classes:[],
           createdAt: Date.now(),
           updatedAt: Date.now()
         });
@@ -2551,19 +2747,28 @@
 
     const activeRecord = libraryItems[0];
     const activeRegistry = Schema.Registry.fromJSON(activeRecord.schema || { tables: [] });
+    const activeClasses = normaliseClasses(activeRecord.classes || []);
 
     function computeLayout(registry, layout){
       const map = Object.assign({}, layout || {});
       const tables = registry.list();
       const fallbackPositions = createAutoLayoutFallbackMap(tables);
-      const used = new Set();
+      const rectIndex = createRectIndex();
       tables.forEach((table, index)=>{
         const baseFallback = fallbackPositions[table.id] || fallbackPositions[table.name] || {
           x: AUTO_LAYOUT_ORIGIN_X + index * FALLBACK_NODE_SPACING_X,
           y: AUTO_LAYOUT_ORIGIN_Y + index * FALLBACK_NODE_SPACING_Y,
         };
         const storedPoint = map[table.id] || map[table.name] || table.layout;
-        const point = claimPoint(storedPoint, baseFallback, used);
+        const fields = Array.isArray(table?.fields) ? table.fields : [];
+        const height = computeTableHeight(fields.length);
+        const point = claimRect(storedPoint, baseFallback, rectIndex, {
+          width: TABLE_WIDTH,
+          height,
+          padding: 48,
+          stepX: AUTO_LAYOUT_COLUMN_GAP,
+          stepY: AUTO_LAYOUT_ROW_GAP
+        });
         const idKey = table?.id != null ? String(table.id) : '';
         const nameKey = table?.name != null ? String(table.name) : (idKey || `table_${index}`);
         if(idKey) map[idKey] = point;
@@ -2595,13 +2800,14 @@
         canvas: normaliseCanvas(activeRecord.canvas),
         sqlPreview:'',
         error:null,
-        library:{ items: libraryItems, status: SchemaLibrary.status }
+        library:{ items: libraryItems, status: SchemaLibrary.status },
+        classes: activeClasses
       },
       ui:{
-        modals:{ import:false, exportJson:false, exportSql:false, table:false, field:false, relation:false, schemaMeta:false, columns:false },
+        modals:{ import:false, exportJson:false, exportSql:false, table:false, field:false, relation:false, schemaMeta:false, columns:false, classification:false },
         template:{ open:true },
         form:{
-          table:{ name:'', nameInput:'', label:'', comment:'', includeId:true },
+          table:{ name:'', nameInput:'', label:'', comment:'', includeId:true, classCode:'' },
           field:{
             table:firstTable || '',
             name:'',
@@ -2632,9 +2838,13 @@
             title: activeRecord.title || '',
             description: activeRecord.description || ''
           },
-          columns:{ table:firstTable || '', rows: buildColumnsFormRows(activeRegistry.get(firstTable || '')) }
+          columns:{ table:firstTable || '', rows: buildColumnsFormRows(activeRegistry.get(firstTable || '')) },
+          classification:{
+            rows: activeClasses.map(item => ({ ...item })),
+            bulkText: activeClasses.length ? JSON.stringify(activeClasses, null, 2) : ''
+          }
         },
-        toolbar:{ exportOpen:false },
+        toolbar:{ exportOpen:false, exportAnchor:null },
         contextMenu:{ open:false, x:0, y:0, type:'canvas', table:'', field:'' },
         hiddenTables:[]
       }
@@ -2790,6 +3000,7 @@
           schema: schemaJSON,
           layout,
           canvas: Object.assign({}, s.data.canvas || {}, { mode:'auto' }),
+          classes: s.data.classes || [],
           createdAt: s.data.schemaCreatedAt,
           updatedAt: now
         };
@@ -2884,6 +3095,7 @@
           schema: schemaJSON,
           layout: s.data.layout,
           canvas: s.data.canvas,
+          classes: s.data.classes || [],
           createdAt: s.data.schemaCreatedAt,
           updatedAt: now
         };
@@ -2928,6 +3140,7 @@
         schema: state.data.schema,
         layout: state.data.layout,
         canvas: state.data.canvas,
+        classes: state.data.classes || [],
         createdAt: state.data.schemaCreatedAt,
         updatedAt: state.data.schemaUpdatedAt
       };
@@ -2963,6 +3176,40 @@
           UI.Button({ attrs:{ gkey:'erd:import:open' }, variant:'ghost', size:'sm' }, [`⬆️ ${t('library.import.button', 'استيراد JSON')}`])
         ]),
         D.Containers.Div({ attrs:{ class: tw`flex-1 overflow-y-auto px-3 pb-4` }}, [listContent])
+      ]);
+    }
+
+    function SchemaClassificationPanel(db){
+      const t = createTranslator(db);
+      const form = db.ui?.form?.classification || {};
+      const rows = Array.isArray(form.rows) ? form.rows : [];
+      const emptyState = rows.length === 0
+        ? D.Text.Span({ attrs:{ class: tw`text-sm text-[var(--muted)]` }}, [t('classification.empty', 'لم يتم تعريف أي فئات بعد.')])
+        : null;
+      const rowNodes = rows.map((row, index) => {
+        const depth = classDepth(row.code || '');
+        const indent = depth > 0 ? `padding-inline-start:${depth * 12}px;` : '';
+        return D.Containers.Div({ attrs:{ class: tw`grid grid-cols-[96px_minmax(0,1fr)_minmax(0,1fr)_auto] items-center gap-2`, key:`class-row-${index}` }}, [
+          UI.Input({ attrs:{ gkey:'erd:classes:update', 'data-index': String(index), 'data-field':'code', value: row.code || '', placeholder:'0101' } }),
+          UI.Input({ attrs:{ gkey:'erd:classes:update', 'data-index': String(index), 'data-field':'name', value: row.name || '', placeholder:t('classification.name', 'Name'), style: indent } }),
+          UI.Input({ attrs:{ gkey:'erd:classes:update', 'data-index': String(index), 'data-field':'parent', value: row.parent || '', placeholder:'01' } }),
+          UI.Button({ attrs:{ gkey:'erd:classes:remove', 'data-index': String(index), class: tw`!px-2 !py-1 text-xs` }, variant:'ghost', size:'xs' }, ['✕'])
+        ]);
+      });
+      const content = rowNodes.length
+        ? rowNodes
+        : [emptyState];
+      const actions = D.Containers.Div({ attrs:{ class: tw`flex flex-wrap gap-2` }}, [
+        UI.Button({ attrs:{ gkey:'erd:classes:add' }, variant:'ghost', size:'sm' }, [`➕ ${t('classification.addRow', 'إضافة صف')}`]),
+        UI.Button({ attrs:{ gkey:'erd:classes:save' }, variant:'solid', size:'sm' }, [`💾 ${t('classification.save', 'حفظ التصنيف')}`]),
+        UI.Button({ attrs:{ gkey:'erd:classes:open-bulk' }, variant:'ghost', size:'sm' }, [`📝 ${t('classification.bulk', 'ترميز الشجرة')}`])
+      ]);
+      return D.Containers.Aside({ attrs:{ class: tw`hidden xl:flex h-full w-80 flex-shrink-0 flex-col border-r border-[var(--border)] bg-[var(--surface-2)]/70 backdrop-blur` }}, [
+        D.Containers.Div({ attrs:{ class: tw`flex items-center justify-between px-4 py-3 border-b border-[var(--border)]` }}, [
+          D.Text.Span({ attrs:{ class: tw`text-base font-semibold` }}, [t('classification.title', 'sche_Tree')])
+        ]),
+        D.Containers.Div({ attrs:{ class: tw`px-4 py-3 flex flex-col gap-3` }}, [actions]),
+        D.Containers.Div({ attrs:{ class: tw`flex-1 overflow-y-auto px-4 pb-4 flex flex-col gap-3` }}, content)
       ]);
     }
 
@@ -3068,9 +3315,40 @@
           }, [item.label])
         ])
       ));
-      const overlay = D.Containers.Div({ attrs:{ class: tw`fixed inset-0 pointer-events-none`, style:'z-index:2147482000;' }}, [
-        D.Containers.Div({ attrs:{ class: tw`absolute left-0 right-0 bottom-0 pointer-events-auto`, style:'top:var(--toolbar-height, 3.5rem);', gkey:'erd:toolbar:export:close' }}, []),
-        D.Containers.Div({ attrs:{ class: tw`absolute pointer-events-auto`, style:'right:1.5rem;top:calc(var(--toolbar-height, 3.5rem) + 0.75rem);' }}, [
+      const anchor = db.ui?.toolbar?.exportAnchor || null;
+      const dir = (db.env?.dir || db.env?.direction || 'rtl').toLowerCase();
+      const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : 0;
+      const viewportHeight = typeof window !== 'undefined' ? window.innerHeight : 0;
+      const estimatedWidth = 260;
+      const estimatedHeight = 320;
+      const margin = 12;
+      let left = margin;
+      let top = margin + 56;
+      if(anchor){
+        if(dir === 'rtl'){
+          left = anchor.right - estimatedWidth;
+          if(left < margin){
+            left = Math.max(margin, anchor.x - estimatedWidth + anchor.width);
+          }
+        } else {
+          left = anchor.x;
+        }
+        if(viewportWidth){
+          const maxLeft = Math.max(margin, viewportWidth - estimatedWidth - margin);
+          if(left > maxLeft) left = maxLeft;
+          if(left < margin) left = margin;
+        }
+        top = anchor.bottom + margin;
+        if(viewportHeight){
+          const maxTop = Math.max(margin, viewportHeight - estimatedHeight - margin);
+          if(top > maxTop) top = maxTop;
+          if(top < margin) top = margin;
+        }
+      }
+      const menuStyle = `left:${Math.round(left)}px;top:${Math.round(top)}px;`;
+      const overlay = D.Containers.Div({ attrs:{ class: tw`absolute inset-0 pointer-events-none` }}, [
+        D.Containers.Div({ attrs:{ class: tw`absolute inset-0 pointer-events-auto`, gkey:'erd:toolbar:export:close' }}, []),
+        D.Containers.Div({ attrs:{ class: tw`absolute pointer-events-auto`, style: menuStyle }}, [
           D.Containers.Div({ attrs:{ id:'erd-toolbar-export-menu', class: tw`min-w-[240px] rounded-2xl border border-[var(--border)] bg-[var(--surface-1)]/95 shadow-xl backdrop-blur-md pointer-events-auto` }}, [list])
         ])
       ]);
@@ -3225,6 +3503,12 @@
         ? t('table.create.helper.suggested', `سيتم حفظ الجدول في قاعدة البيانات بالاسم: ${suggestedName} مع ضمان عدم تكرار المعرف داخل المخطط.`)
         : t('table.create.helper.prompt', 'اكتب اسمًا إنجليزيًا، وسيتم تحويل المسافات والمحارف الخاصة تلقائيًا إلى صيغة SQL سليمة.');
       const helperText = helperTemplate.replace('{name}', suggestedName);
+      const classRows = Array.isArray(db.data?.classes) ? db.data.classes : [];
+      const leafClasses = computeClassLeaves(classRows);
+      const classOptions = leafClasses.map(item => ({
+        value: item.code,
+        label: item.name ? `${item.code} — ${item.name}` : item.code
+      }));
       return UI.Modal({
         open,
         size:'md',
@@ -3237,6 +3521,16 @@
             D.Text.Span({ attrs:{ class: tw`text-xs text-[var(--muted)]` }}, [helperText]),
             UI.Input({ attrs:{ gkey:'erd:form:update', 'data-form':'table', 'data-field':'label', value: form.label || '', placeholder:t('modal.table.label.placeholder', 'اسم الجدول بلغة ثانية (اختياري)') } }),
             UI.Textarea({ attrs:{ gkey:'erd:form:update', 'data-form':'table', 'data-field':'comment', value: form.comment || '', rows:3, placeholder:t('common.notes.placeholder', 'ملاحظات') } }),
+            UI.Select({
+              attrs:{
+                gkey:'erd:form:update',
+                'data-form':'table',
+                'data-field':'classCode',
+                value: form.classCode || ''
+              },
+              options:[{ value:'', label:t('modal.table.class.placeholder', 'اختر الفئة') }, ...classOptions]
+            }),
+            classOptions.length ? null : D.Text.Span({ attrs:{ class: tw`text-xs text-[var(--muted)]` }}, [t('classification.leaf.only', 'يرجى اختيار كود نهائي من الشجرة.')]),
             D.Containers.Div({ attrs:{ class: tw`flex items-center gap-2` }}, [
               UI.Input({ attrs:{ gkey:'erd:form:toggle', 'data-form':'table', 'data-field':'includeId', type:'checkbox', checked: form.includeId !== false } }),
               UI.Label({ text:t('modal.table.includeId', 'إنشاء حقل id افتراضي؟') })
@@ -3572,6 +3866,27 @@
       });
     }
 
+    function ModalClassificationBulk(db){
+      const t = createTranslator(db);
+      const open = db.ui?.modals?.classification;
+      const form = db.ui?.form?.classification || {};
+      const text = form.bulkText || '';
+      return UI.Modal({
+        open,
+        size:'lg',
+        title:t('modal.classification.title', 'إدارة ترميز الشجرة'),
+        description:t('modal.classification.description', 'حرر قائمة الفئات بصيغة JSON (code، name، parent).'),
+        closeGkey:'erd:modal:close',
+        content:[
+          UI.Textarea({ attrs:{ gkey:'erd:classes:update-bulk', value: text, rows:14, placeholder:t('modal.classification.placeholder', '[{"code":"01","name":"Root","parent":null}]') } })
+        ],
+        actions:[
+          UI.Button({ attrs:{ gkey:'erd:classes:apply-bulk', variant:'solid', size:'sm' }}, [t('modal.classification.apply', 'تطبيق')]),
+          UI.Button({ attrs:{ gkey:'erd:modal:close', variant:'ghost', size:'sm' }}, [t('common.cancel', 'إلغاء')])
+        ]
+      });
+    }
+
     function buildContextMenuSections(menu, db){
       const sections = [];
       const registry = getRegistry(db);
@@ -3663,8 +3978,17 @@
       const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : 0;
       const viewportHeight = typeof window !== 'undefined' ? window.innerHeight : 0;
       const menuWidth = 260;
-      const safeLeft = viewportWidth ? Math.min(menu.x, Math.max(0, viewportWidth - menuWidth - 12)) : menu.x;
-      const safeTop = viewportHeight ? Math.min(menu.y, Math.max(0, viewportHeight - 24 - 12)) : menu.y;
+      const estimatedHeight = Math.max(180, sections.reduce((total, section)=>{
+        const count = (section.items || []).length;
+        return total + (section.label ? 32 : 0) + count * 36 + 16;
+      }, 0));
+      const margin = 12;
+      const safeLeft = viewportWidth
+        ? Math.max(margin, Math.min(menu.x, viewportWidth - menuWidth - margin))
+        : menu.x;
+      const safeTop = viewportHeight
+        ? Math.max(margin, Math.min(menu.y, viewportHeight - estimatedHeight - margin))
+        : menu.y;
       const sectionNodes = sections.map(section => {
         const header = section.label
           ? D.Text.Span({ attrs:{ class: tw`px-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--muted)]` }}, [section.label])
@@ -3686,9 +4010,9 @@
         ].filter(Boolean)));
         return D.Containers.Div({ attrs:{ class: tw`flex flex-col gap-1` }}, [header, ...items.filter(Boolean)].filter(Boolean));
       });
-      return D.Containers.Div({ attrs:{ class: tw`fixed inset-0 z-[200] pointer-events-none` }}, [
+      return D.Containers.Div({ attrs:{ class: tw`absolute inset-0 pointer-events-none` }}, [
         D.Containers.Div({ attrs:{ class: tw`absolute inset-0 pointer-events-auto`, gkey:'erd:context:close' }}, []),
-        D.Containers.Div({ attrs:{ class: tw`absolute pointer-events-auto`, style:`left:${safeLeft}px;top:${safeTop}px;` }}, [
+        D.Containers.Div({ attrs:{ class: tw`absolute pointer-events-auto`, style:`left:${Math.round(safeLeft)}px;top:${Math.round(safeTop)}px;` }}, [
           D.Containers.Div({ attrs:{ class: tw`min-w-[220px] max-w-[280px] rounded-2xl border border-[var(--border)] bg-[var(--surface-1)]/95 p-2 shadow-2xl flex flex-col gap-2` }}, sectionNodes)
         ])
       ]);
@@ -3703,26 +4027,38 @@
         ModalAddTable(db),
         ModalAddField(db),
         ModalRelation(db),
-        ModalColumnsManager(db)
+        ModalColumnsManager(db),
+        ModalClassificationBulk(db)
       ];
+    }
+
+    function OverlayLayer(children){
+      const nodes = Array.isArray(children) ? children.filter(Boolean) : [];
+      if(!nodes.length) return null;
+      return D.Containers.Div({ attrs:{ id:'erd-overlay-root', class: tw`fixed inset-0 pointer-events-none z-[2147483000]` }}, nodes);
     }
 
     function AppView(db){
       const toolbarResult = Toolbar(db);
       const toolbarView = toolbarResult && toolbarResult.view ? toolbarResult.view : toolbarResult;
       const toolbarOverlays = (toolbarResult && Array.isArray(toolbarResult.overlays) ? toolbarResult.overlays : []).filter(Boolean);
+      const overlayNodes = [
+        ...toolbarOverlays,
+        ContextMenu(db),
+        ...Modals(db)
+      ].filter(Boolean);
+      const overlayRoot = OverlayLayer(overlayNodes);
       return D.Containers.Div({ attrs:{ class: tw`flex h-screen w-full flex-col bg-[var(--surface-0)] text-[var(--foreground)]` }}, [
         toolbarView,
         D.Containers.Div({ attrs:{ class: tw`flex flex-1 min-h-0 w-full` }}, [
           SchemaLibraryPanel(db),
           D.Containers.Div({ attrs:{ class: tw`flex flex-1 flex-col min-h-0` }}, [
             SchemaCanvas(db)
-          ])
+          ]),
+          SchemaClassificationPanel(db)
         ]),
-        ...toolbarOverlays,
-        ContextMenu(db),
-        ...Modals(db)
-      ]);
+        overlayRoot
+      ].filter(Boolean));
     }
 
     const erdOrders = {
@@ -3777,6 +4113,7 @@
               schema: s.data.schema,
               layout: s.data.layout,
               canvas,
+              classes: s.data.classes || [],
               createdAt: s.data.schemaCreatedAt,
               updatedAt: s.data.schemaUpdatedAt
             };
@@ -3810,6 +4147,7 @@
               schema: s.data.schema,
               layout: s.data.layout,
               canvas,
+              classes: s.data.classes || [],
               createdAt: s.data.schemaCreatedAt,
               updatedAt: s.data.schemaUpdatedAt
             };
@@ -3842,6 +4180,7 @@
               schema: s.data.schema,
               layout: s.data.layout,
               canvas,
+              classes: s.data.classes || [],
               createdAt: s.data.schemaCreatedAt,
               updatedAt: s.data.schemaUpdatedAt
             };
@@ -3863,13 +4202,27 @@
         on:['click'],
         gkeys:['erd:toolbar:export'],
         handler:(e,ctx)=>{
+          const target = e.currentTarget || e.target;
+          let anchor = null;
+          if(target && typeof target.getBoundingClientRect === 'function'){
+            const rect = target.getBoundingClientRect();
+            anchor = {
+              x: rect.left,
+              y: rect.top,
+              width: rect.width,
+              height: rect.height,
+              right: rect.right,
+              bottom: rect.bottom
+            };
+          }
           ctx.setState(s=>({
             ...s,
             ui:{
               ...(s.ui || {}),
               toolbar:{
                 ...(s.ui?.toolbar || {}),
-                exportOpen: !(s.ui?.toolbar?.exportOpen)
+                exportOpen: !(s.ui?.toolbar?.exportOpen),
+                exportAnchor: !(s.ui?.toolbar?.exportOpen) ? anchor : null
               }
             }
           }));
@@ -3884,7 +4237,7 @@
             ...s,
             ui:{
               ...(s.ui || {}),
-              toolbar:{ ...(s.ui?.toolbar || {}), exportOpen:false }
+              toolbar:{ ...(s.ui?.toolbar || {}), exportOpen:false, exportAnchor:null }
             }
           }));
           ctx.rebuild();
@@ -4035,7 +4388,8 @@
             description: state.data.schemaMeta?.description || '',
             schema: state.data.schema,
             layout: state.data.layout,
-            canvas: state.data.canvas
+            canvas: state.data.canvas,
+            classes: state.data.classes || []
           };
           ctx.setState(s=>({
             ...s,
@@ -4054,7 +4408,7 @@
         handler:(e,ctx)=>{
           ctx.setState(s=>({
             ...s,
-            ui:{ ...(s.ui || {}), modals:{ import:false, exportJson:false, exportSql:false, table:false, field:false, relation:false, schemaMeta:false, columns:false } }
+            ui:{ ...(s.ui || {}), modals:{ import:false, exportJson:false, exportSql:false, table:false, field:false, relation:false, schemaMeta:false, columns:false, classification:false } }
           }));
           ctx.rebuild();
         }
@@ -4272,6 +4626,7 @@
               label: label || '',
               comment: form.comment || '',
               layout: fallbackPosition,
+              classCode: form.classCode || '',
               fields: []
             };
             if(form.includeId){
@@ -4291,6 +4646,7 @@
                 schema: schemaJSON,
                 layout,
                 canvas: s.data.canvas,
+                classes: s.data.classes || [],
                 createdAt: s.data.schemaCreatedAt,
                 updatedAt: now
               };
@@ -4309,7 +4665,7 @@
                   modals:{ ...(s.ui?.modals || {}), table:false },
                   form:{
                     ...(s.ui?.form || {}),
-                    table:{ name:'', nameInput:'', label:'', comment:'', includeId:true },
+                    table:{ name:'', nameInput:'', label:'', comment:'', includeId:true, classCode:'' },
                     field:{ ...(s.ui?.form?.field || {}), table: name, label:'', name:'', nameInput:'', nameManual:false, columnName:'' },
                     layout:{ x: layout[name].x, y: layout[name].y }
                   }
@@ -4477,6 +4833,7 @@
                 schema: schemaJSON,
                 layout: s.data.layout,
                 canvas: s.data.canvas,
+                classes: s.data.classes || [],
                 createdAt: s.data.schemaCreatedAt,
                 updatedAt: now
               };
@@ -4842,6 +5199,7 @@
               schema: schemaJSON,
               layout: s.data.layout,
               canvas: s.data.canvas,
+              classes: s.data.classes || [],
               createdAt: s.data.schemaCreatedAt,
               updatedAt: now
             };
@@ -4874,6 +5232,176 @@
           ctx.rebuild();
           if(persistRecord) schedulePersist(recordFromState(nextState));
           UI.pushToast(ctx, { title:'تم حفظ الأعمدة بنجاح', icon:'✅' });
+        }
+      },
+      'erd.classes.add':{
+        on:['click'],
+        gkeys:['erd:classes:add'],
+        handler:(e,ctx)=>{
+          ctx.setState(s => {
+            const classificationForm = s.ui?.form?.classification || {};
+            const rows = Array.isArray(classificationForm.rows) ? classificationForm.rows.slice() : [];
+            rows.push({ code:'', name:'', parent:'' });
+            return {
+              ...s,
+              ui:{
+                ...(s.ui || {}),
+                form:{
+                  ...(s.ui?.form || {}),
+                  classification:{ ...(classificationForm || {}), rows }
+                }
+              }
+            };
+          });
+          ctx.rebuild();
+        }
+      },
+      'erd.classes.update':{
+        on:['input','change'],
+        gkeys:['erd:classes:update'],
+        handler:(e,ctx)=>{
+          const input = e.target;
+          const index = Number(input?.getAttribute('data-index'));
+          const field = input?.getAttribute('data-field');
+          if(!Number.isInteger(index) || !field) return;
+          const value = input.value;
+          ctx.setState(s => {
+            const classificationForm = s.ui?.form?.classification || {};
+            const rows = Array.isArray(classificationForm.rows) ? classificationForm.rows.slice() : [];
+            if(!rows[index]) return s;
+            const nextRows = rows.slice();
+            nextRows[index] = { ...nextRows[index], [field]: value };
+            return {
+              ...s,
+              ui:{
+                ...(s.ui || {}),
+                form:{
+                  ...(s.ui?.form || {}),
+                  classification:{ ...(classificationForm || {}), rows: nextRows }
+                }
+              }
+            };
+          });
+          ctx.rebuild();
+        }
+      },
+      'erd.classes.remove':{
+        on:['click'],
+        gkeys:['erd:classes:remove'],
+        handler:(e,ctx)=>{
+          const button = e.currentTarget || e.target;
+          const index = Number(button?.getAttribute('data-index'));
+          if(!Number.isInteger(index)) return;
+          ctx.setState(s => {
+            const classificationForm = s.ui?.form?.classification || {};
+            const rows = Array.isArray(classificationForm.rows) ? classificationForm.rows.slice() : [];
+            if(index < 0 || index >= rows.length) return s;
+            rows.splice(index, 1);
+            return {
+              ...s,
+              ui:{
+                ...(s.ui || {}),
+                form:{
+                  ...(s.ui?.form || {}),
+                  classification:{ ...(classificationForm || {}), rows }
+                }
+              }
+            };
+          });
+          ctx.rebuild();
+        }
+      },
+      'erd.classes.save':{
+        on:['click'],
+        gkeys:['erd:classes:save'],
+        handler:(e,ctx)=>{
+          const state = ctx.getState();
+          const rows = Array.isArray(state.ui?.form?.classification?.rows) ? state.ui.form.classification.rows : [];
+          const normalized = normaliseClasses(rows);
+          const filled = rows.filter(row => (row && row.code != null && String(row.code).trim() !== ''));
+          if(normalized.length !== filled.length){
+            UI.pushToast(ctx, { title:'تحقق من الأكواد', message:'يرجى استخدام صيغ صحيحة من خانتين لكل مستوى وعدم تكرار الأكواد.', icon:'⚠️' });
+            return;
+          }
+          const codeSet = new Set(normalized.map(item => item.code));
+          const invalidParent = normalized.find(item => item.parent && !codeSet.has(item.parent));
+          if(invalidParent){
+            UI.pushToast(ctx, { title:'أكواد الآباء غير موجودة', message:`${invalidParent.parent} غير معرف كأب`, icon:'⚠️' });
+            return;
+          }
+          commitClasses(ctx, normalized);
+          UI.pushToast(ctx, { title:'تم حفظ الشجرة', icon:'✅' });
+        }
+      },
+      'erd.classes.open-bulk':{
+        on:['click'],
+        gkeys:['erd:classes:open-bulk'],
+        handler:(e,ctx)=>{
+          const state = ctx.getState();
+          const rows = Array.isArray(state.ui?.form?.classification?.rows) ? state.ui.form.classification.rows : [];
+          const normalized = normaliseClasses(rows);
+          ctx.setState(s => ({
+            ...s,
+            ui:{
+              ...(s.ui || {}),
+              modals:{ ...(s.ui?.modals || {}), classification:true },
+              form:{
+                ...(s.ui?.form || {}),
+                classification:{ ...(s.ui?.form?.classification || {}), bulkText: normalized.length ? JSON.stringify(normalized, null, 2) : '' }
+              }
+            }
+          }));
+          ctx.rebuild();
+        }
+      },
+      'erd.classes.update-bulk':{
+        on:['input','change'],
+        gkeys:['erd:classes:update-bulk'],
+        handler:(e,ctx)=>{
+          const value = e.target?.value ?? '';
+          ctx.setState(s => ({
+            ...s,
+            ui:{
+              ...(s.ui || {}),
+              form:{
+                ...(s.ui?.form || {}),
+                classification:{ ...(s.ui?.form?.classification || {}), bulkText:value }
+              }
+            }
+          }));
+        }
+      },
+      'erd.classes.apply-bulk':{
+        on:['click'],
+        gkeys:['erd:classes:apply-bulk'],
+        handler:(e,ctx)=>{
+          const state = ctx.getState();
+          const text = state.ui?.form?.classification?.bulkText || '';
+          let parsed;
+          try {
+            parsed = JSON.parse(text || '[]');
+          } catch(error){
+            UI.pushToast(ctx, { title:'تعذر قراءة البيانات', message:String(error), icon:'🛑' });
+            return;
+          }
+          if(!Array.isArray(parsed)){
+            UI.pushToast(ctx, { title:'صيغة غير صحيحة', message:'استخدم مصفوفة JSON تحتوي على عناصر {code,name,parent}.', icon:'⚠️' });
+            return;
+          }
+          const normalized = normaliseClasses(parsed);
+          const filled = parsed.filter(item => item && item.code != null && String(item.code).trim() !== '');
+          if(normalized.length !== filled.length){
+            UI.pushToast(ctx, { title:'تحقق من الأكواد', message:'يوجد أكواد غير صالحة أو مكررة.', icon:'⚠️' });
+            return;
+          }
+          const codeSet = new Set(normalized.map(item => item.code));
+          const invalidParent = normalized.find(item => item.parent && !codeSet.has(item.parent));
+          if(invalidParent){
+            UI.pushToast(ctx, { title:'أكواد الآباء غير موجودة', message:`${invalidParent.parent} غير معرف كأب`, icon:'⚠️' });
+            return;
+          }
+          commitClasses(ctx, normalized, { closeModal:true });
+          UI.pushToast(ctx, { title:'تم تحديث الشجرة', icon:'✅' });
         }
       },
       'erd.context.close':{
@@ -5119,7 +5647,12 @@
             const targetId = form.targetId || '';
             let existing = null;
             if(targetId){ existing = await SchemaLibrary.get(targetId); }
+            const classesSource = parsed.classes != null ? parsed.classes : parsed.classification;
+            const importedClasses = classesSource != null
+              ? normaliseClasses(classesSource)
+              : normaliseClasses(existing?.classes || state.data.classes || []);
             const now = Date.now();
+            const canvasState = normaliseCanvas(parsed.canvas || existing?.canvas || state.data.canvas);
             const recordInput = {
               id: targetId || undefined,
               name: form.name || parsed.name || schemaPayload.name || `schema_${now}`,
@@ -5127,7 +5660,8 @@
               description: parsed.description || '',
               schema: normalizedSchema,
               layout,
-            canvas: normaliseCanvas(parsed.canvas || existing?.canvas || state.data.canvas),
+              canvas: canvasState,
+              classes: importedClasses,
               createdAt: existing?.createdAt,
               updatedAt: now
             };
@@ -5147,7 +5681,8 @@
                 schema: normalizedSchema,
                 layout,
                 selection:{ table:first, field:null },
-            canvas: normaliseCanvas(saved.canvas || state.data.canvas),
+                canvas: canvasState,
+                classes: importedClasses,
                 library:{ ...(s.data.library || {}), items: list }
               },
               ui:{
@@ -5158,7 +5693,9 @@
                   import:{ name:'', title:'', targetId:'', text:'' },
                   layout:{ x: layoutPoint.x, y: layoutPoint.y },
                   field:{ ...(s.ui?.form?.field || {}), table:first || '' },
-                  schemaMeta:{ name: saved.name, title: saved.title, description: saved.description || '' }
+                  schemaMeta:{ name: saved.name, title: saved.title, description: saved.description || '' },
+                  classification:{ rows: importedClasses.map(item => ({ ...item })), bulkText: importedClasses.length ? JSON.stringify(importedClasses, null, 2) : '' },
+                  table:{ ...(s.ui?.form?.table || {}), classCode:'' }
                 }
               }
             }));
@@ -5208,6 +5745,7 @@
               schema: s.data.schema,
               layout,
               canvas: s.data.canvas,
+              classes: s.data.classes || [],
               createdAt: s.data.schemaCreatedAt,
               updatedAt: now
             };
@@ -5237,6 +5775,11 @@
             const list = await SchemaLibrary.list();
             const first = registry.list()[0]?.name || null;
             const layoutPoint = first ? (layout[first] || { x:120, y:120 }) : { x:120, y:120 };
+            const classes = normaliseClasses(record.classes || []);
+            const classificationForm = {
+              rows: classes.map(item => ({ ...item })),
+              bulkText: classes.length ? JSON.stringify(classes, null, 2) : ''
+            };
             ctx.setState(s=>({
               ...s,
               head:{ ...(s.head || {}), title: record.title || 'مخطط قاعدة بيانات مشكاة' },
@@ -5250,17 +5793,19 @@
                 layout,
                 selection:{ table:first, field:null },
                 canvas: normaliseCanvas(record.canvas),
-                library:{ ...(s.data.library || {}), items: list }
+                library:{ ...(s.data.library || {}), items: list },
+                classes
               },
               ui:{
                 ...(s.ui || {}),
                 form:{
                   ...(s.ui?.form || {}),
-                  table:{ name:'', nameInput:'', label:'', comment:'', includeId:true },
+                  table:{ name:'', nameInput:'', label:'', comment:'', includeId:true, classCode:'' },
                   field:{ table:first || '', label:'', name:'', nameInput:'', nameManual:false, columnName:'', type:'string', nullable:true, primaryKey:false, unique:false, defaultValue:'', references:{ table:'', column:'', onDelete:'CASCADE', onUpdate:'CASCADE' } },
                   relation:{ sourceTable:first || '', sourceField:'', targetTable:'', targetField:'', onDelete:'CASCADE', onUpdate:'CASCADE' },
                   layout:{ x: layoutPoint.x, y: layoutPoint.y },
-                  schemaMeta:{ name: record.name, title: record.title, description: record.description || '' }
+                  schemaMeta:{ name: record.name, title: record.title, description: record.description || '' },
+                  classification: classificationForm
                 }
               }
             }));
@@ -5292,6 +5837,11 @@
             const list = await SchemaLibrary.list();
             const first = registry.list()[0]?.name || null;
             const layoutPoint = first ? (layout[first] || { x:120, y:120 }) : { x:120, y:120 };
+            const classes = normaliseClasses(record.classes || []);
+            const classificationForm = {
+              rows: classes.map(item => ({ ...item })),
+              bulkText: classes.length ? JSON.stringify(classes, null, 2) : ''
+            };
             ctx.setState(s=>({
               ...s,
               head:{ ...(s.head || {}), title: record.title || 'مخطط قاعدة بيانات مشكاة' },
@@ -5305,7 +5855,8 @@
                 layout,
                 selection:{ table:first, field:null },
                 canvas: normaliseCanvas(record.canvas),
-                library:{ ...(s.data.library || {}), items: list }
+                library:{ ...(s.data.library || {}), items: list },
+                classes
               },
               ui:{
                 ...(s.ui || {}),
@@ -5314,7 +5865,9 @@
                   field:{ ...(s.ui?.form?.field || {}), table:first || '' },
                   relation:{ ...(s.ui?.form?.relation || {}), sourceTable:first || '', sourceField:'', targetTable:'', targetField:'', onDelete:'CASCADE', onUpdate:'CASCADE' },
                   layout:{ x: layoutPoint.x, y: layoutPoint.y },
-                  schemaMeta:{ name: record.name, title: record.title, description: record.description || '' }
+                  schemaMeta:{ name: record.name, title: record.title, description: record.description || '' },
+                  classification: classificationForm,
+                  table:{ ...(s.ui?.form?.table || {}), classCode:'' }
                 }
               }
             }));
@@ -5358,6 +5911,11 @@
             const layout = computeLayout(registry, record.layout);
             const first = registry.list()[0]?.name || null;
             const layoutPoint = first ? (layout[first] || { x:120, y:120 }) : { x:120, y:120 };
+            const classes = normaliseClasses(record.classes || []);
+            const classificationForm = {
+              rows: classes.map(item => ({ ...item })),
+              bulkText: classes.length ? JSON.stringify(classes, null, 2) : ''
+            };
             ctx.setState(s=>({
               ...s,
               head:{ ...(s.head || {}), title: record.title || 'مخطط قاعدة بيانات مشكاة' },
@@ -5371,7 +5929,8 @@
                 layout,
                 selection:{ table:first, field:null },
                 canvas: normaliseCanvas(record.canvas),
-                library:{ ...(s.data.library || {}), items: list }
+                library:{ ...(s.data.library || {}), items: list },
+                classes
               },
               ui:{
                 ...(s.ui || {}),
@@ -5380,7 +5939,9 @@
                   field:{ ...(s.ui?.form?.field || {}), table:first || '' },
                   relation:{ ...(s.ui?.form?.relation || {}), sourceTable:first || '', sourceField:'', targetTable:'', targetField:'', onDelete:'CASCADE', onUpdate:'CASCADE' },
                   layout:{ x: layoutPoint.x, y: layoutPoint.y },
-                  schemaMeta:{ name: record.name, title: record.title, description: record.description || '' }
+                  schemaMeta:{ name: record.name, title: record.title, description: record.description || '' },
+                  classification: classificationForm,
+                  table:{ ...(s.ui?.form?.table || {}), classCode:'' }
                 }
               }
             }));
@@ -5428,6 +5989,7 @@
               schema: s.data.schema,
               layout: s.data.layout,
               canvas: s.data.canvas,
+              classes: s.data.classes || [],
               createdAt: s.data.schemaCreatedAt,
               updatedAt: now
             };

--- a/mishkah-schema.js
+++ b/mishkah-schema.js
@@ -261,6 +261,7 @@
       this.comment = config.comment || '';
       this.sqlName = config.sqlName || toSnakeCase(this.name);
       this.layout = Object.assign({ x:0, y:0 }, config.layout || {});
+      this.classCode = config.classCode || config.class || '';
       const fields = ensureArray(config.fields).map(field => field instanceof FieldDefinition ? field : new FieldDefinition(field));
       this.fields = fields;
       this.indexes = ensureArray(config.indexes).map(idx => Object.assign({}, idx));
@@ -342,6 +343,7 @@
         comment: this.comment,
         sqlName: this.sqlName,
         layout: Object.assign({}, this.layout),
+        classCode: this.classCode || '',
         fields: this.fields.map(field => field.toJSON()),
         indexes: this.indexes.map(idx => Object.assign({}, idx))
       };


### PR DESCRIPTION
## Summary
- persist table class codes by capturing classCode on TableDefinition serialisation
- include classes in ERD import/export payloads and propagate them to state and forms
- normalise classification data during library actions and when persisting schema updates so records stay in sync

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5b2c6de1c8333955270e8444c11f2