### PR TITLE
Add realtime signaling backend skeleton and Mishkah UI

### DIFF
--- a/mishkah.pages.realtime.js
+++ b/mishkah.pages.realtime.js
@@ -1,0 +1,885 @@
+(function (window) {
+  'use strict';
+
+  if (!window || !window.Mishkah) {
+    return;
+  }
+
+  const M = window.Mishkah;
+  const D = M.DSL;
+  const Templates = M.templates = M.templates || {};
+  const U = M.utils = M.utils || {};
+  const tw = (U.twcss && U.twcss.tw) || ((s) => s);
+
+  const DEFAULT_SIGNAL_BASE = '/api';
+  const DEFAULT_WS_URL = 'ws://localhost:3001';
+  const DEFAULT_CONVERSATION = 'conv-demo';
+
+  const runtime = {
+    app: null,
+    lastCtx: null,
+    ws: null,
+    wsStatus: 'idle',
+    wsReconnect: null,
+    peer: null,
+    dataChannel: null,
+    remoteStream: null,
+    localStream: null,
+    recorder: null,
+    recorderChunks: [],
+    mediaTracks: { audio: null, video: null },
+    signalQueue: [],
+  };
+
+  function normalizeState(state) {
+    const rt = state.data?.realtime || {};
+    return {
+      conversationId: rt.conversationId || DEFAULT_CONVERSATION,
+      signalBase: rt.signalBase || DEFAULT_SIGNAL_BASE,
+      wsUrl: rt.wsUrl || DEFAULT_WS_URL,
+      token: rt.token || null,
+      iceServers: rt.iceServers || [],
+      turnHint: rt.turnHint || null,
+      call: rt.call || { status: 'idle', micEnabled: true, camEnabled: true },
+      chat: rt.chat || { transport: 'dc', messages: [], sending: false },
+      connection: rt.connection || { ws: 'idle', dc: 'idle' },
+      voiceNote: rt.voiceNote || { recording: false, lastError: null },
+    };
+  }
+
+  function updateState(updater) {
+    if (runtime.app) {
+      runtime.app.setState(updater);
+      runtime.app.rebuild();
+    } else if (runtime.lastCtx) {
+      runtime.lastCtx.setState(updater);
+      runtime.lastCtx.rebuild();
+    }
+  }
+
+  function encryptText(plaintext) {
+    if (!plaintext) {
+      return { ciphertext: '', keyId: null };
+    }
+    return { ciphertext: plaintext, keyId: null };
+  }
+
+  function decryptText(ciphertext) {
+    return ciphertext;
+  }
+
+  function appendChatMessage(message) {
+    updateState((state) => {
+      const current = state.data?.realtime?.chat?.messages || [];
+      const next = current.concat([message]).slice(-200);
+      return {
+        ...state,
+        data: {
+          ...state.data,
+          realtime: {
+            ...(state.data?.realtime || {}),
+            chat: {
+              ...(state.data?.realtime?.chat || {}),
+              messages: next,
+            },
+          },
+        },
+      };
+    });
+  }
+
+  function setConnectionStatus(target, status) {
+    updateState((state) => ({
+      ...state,
+      data: {
+        ...state.data,
+        realtime: {
+          ...(state.data?.realtime || {}),
+          connection: {
+            ...(state.data?.realtime?.connection || {}),
+            [target]: status,
+          },
+        },
+      },
+    }));
+  }
+
+  function getAuthHeaders(state) {
+    if (!state.token) return {};
+    return { Authorization: `Bearer ${state.token}` };
+  }
+
+  function wsSend(obj) {
+    if (!runtime.ws || runtime.ws.readyState !== 1) return;
+    runtime.ws.send(JSON.stringify(obj));
+  }
+
+  function subscribeTopics(state) {
+    const topics = [
+      `chat:${state.conversationId}`,
+      `rtc:${state.conversationId}`,
+    ];
+    topics.forEach((topic) => {
+      wsSend({ type: 'subscribe', topic });
+    });
+  }
+
+  function handleSignalMessage(payload, state) {
+    if (!payload || payload.topic !== `rtc:${state.conversationId}`) {
+      return;
+    }
+    const data = payload.data || {};
+    if (!runtime.peer) {
+      runtime.signalQueue.push(data);
+      return;
+    }
+    if (data.kind === 'answer' && data.sdp) {
+      runtime.peer.setRemoteDescription(new RTCSessionDescription({ type: 'answer', sdp: data.sdp })).catch(() => {
+        /* ignore for skeleton */
+      });
+    } else if (data.kind === 'offer' && data.sdp) {
+      // Remote initiated call
+      acceptRemoteOffer(data, state).catch(() => {});
+    } else if (data.kind === 'ice' && data.candidate) {
+      try {
+        runtime.peer.addIceCandidate(new RTCIceCandidate({
+          candidate: data.candidate,
+          sdpMid: data.sdpMid || undefined,
+          sdpMLineIndex: data.sdpMLineIndex ?? undefined,
+        }));
+      } catch (_err) {
+        /* ignore */
+      }
+    }
+  }
+
+  function handleChatPublish(payload, state) {
+    if (!payload || payload.topic !== `chat:${state.conversationId}`) {
+      return;
+    }
+    appendChatMessage(payload.data || {});
+  }
+
+  function setupWebSocket(ctx) {
+    runtime.lastCtx = ctx;
+    const state = normalizeState(ctx.getState());
+    if (!state.wsUrl) {
+      return null;
+    }
+    if (runtime.ws && runtime.ws.readyState <= 1) {
+      return runtime.ws;
+    }
+    try {
+      const query = state.token ? (state.wsUrl.includes('?') ? '&' : '?') + `token=${encodeURIComponent(state.token)}` : '';
+      const ws = new window.WebSocket(`${state.wsUrl}${query}`);
+      runtime.ws = ws;
+      runtime.wsStatus = 'connecting';
+      setConnectionStatus('ws', 'connecting');
+      ws.onopen = () => {
+        runtime.wsStatus = 'connected';
+        setConnectionStatus('ws', 'connected');
+        if (state.token && !state.wsUrl.includes('token=')) {
+          wsSend({ type: 'auth', data: { token: state.token } });
+        }
+        subscribeTopics(state);
+      };
+      ws.onclose = () => {
+        runtime.wsStatus = 'closed';
+        setConnectionStatus('ws', 'closed');
+        runtime.ws = null;
+      };
+      ws.onerror = () => {
+        runtime.wsStatus = 'error';
+        setConnectionStatus('ws', 'error');
+      };
+      ws.onmessage = (event) => {
+        const message = U.JSON.parseSafe(event.data, null);
+        if (!message) return;
+        if (message.type === 'publish') {
+          handleSignalMessage(message, state);
+          handleChatPublish(message, state);
+        } else if (message.type === 'chat:history') {
+          const messages = Array.isArray(message.messages) ? message.messages : [];
+          messages.forEach(appendChatMessage);
+        } else if (message.type === 'ack' && message.event === 'chat:send' && message.message) {
+          appendChatMessage(message.message);
+        }
+      };
+      return ws;
+    } catch (_err) {
+      setConnectionStatus('ws', 'error');
+      return null;
+    }
+  }
+
+  async function postJSON(url, body, headers) {
+    return U.Net.post(url, {
+      headers: { 'Content-Type': 'application/json', ...(headers || {}) },
+      body,
+    });
+  }
+
+  async function sendOfferToServer(state, offer, candidates) {
+    const endpoint = `${state.signalBase.replace(/\/$/, '')}/rtc/${encodeURIComponent(state.conversationId)}/offer`;
+    await postJSON(endpoint, {
+      sdp: offer.sdp,
+      candidates: candidates || [],
+      meta: { via: 'client', ts: Date.now() },
+    }, getAuthHeaders(state));
+  }
+
+  async function sendAnswerToServer(state, answer, candidates) {
+    const endpoint = `${state.signalBase.replace(/\/$/, '')}/rtc/${encodeURIComponent(state.conversationId)}/answer`;
+    await postJSON(endpoint, {
+      sdp: answer.sdp,
+      candidates: candidates || [],
+      meta: { via: 'client', ts: Date.now() },
+    }, getAuthHeaders(state));
+  }
+
+  async function sendIceCandidate(state, candidate) {
+    if (!candidate) return;
+    const endpoint = `${state.signalBase.replace(/\/$/, '')}/rtc/${encodeURIComponent(state.conversationId)}/ice`;
+    await postJSON(endpoint, {
+      candidate: candidate.candidate,
+      sdpMid: candidate.sdpMid,
+      sdpMLineIndex: candidate.sdpMLineIndex,
+      meta: { via: 'client', ts: Date.now() },
+    }, getAuthHeaders(state));
+  }
+
+  function resetPeerState() {
+    if (runtime.dataChannel) {
+      runtime.dataChannel.close();
+    }
+    if (runtime.peer) {
+      runtime.peer.close();
+    }
+    runtime.peer = null;
+    runtime.dataChannel = null;
+    runtime.remoteStream = null;
+    runtime.localStream = null;
+    runtime.mediaTracks = { audio: null, video: null };
+    setConnectionStatus('dc', 'idle');
+  }
+
+  function attachRemoteStream(stream) {
+    runtime.remoteStream = stream;
+    const video = document.getElementById('realtime-remote-video');
+    if (video && video.srcObject !== stream) {
+      video.srcObject = stream;
+    }
+  }
+
+  function attachLocalStream(stream) {
+    runtime.localStream = stream;
+    const video = document.getElementById('realtime-local-video');
+    if (video && video.srcObject !== stream) {
+      video.srcObject = stream;
+    }
+  }
+
+  function ensureLocalMedia(state) {
+    if (runtime.localStream) {
+      return runtime.localStream;
+    }
+    return navigator.mediaDevices.getUserMedia({ audio: true, video: true })
+      .then((stream) => {
+        attachLocalStream(stream);
+        runtime.mediaTracks.audio = stream.getAudioTracks()[0] || null;
+        runtime.mediaTracks.video = stream.getVideoTracks()[0] || null;
+        return stream;
+      })
+      .catch((err) => {
+        updateState((s) => ({
+          ...s,
+          data: {
+            ...s.data,
+            realtime: {
+              ...(s.data?.realtime || {}),
+              call: {
+                ...(s.data?.realtime?.call || {}),
+                lastError: err?.message || 'Media access denied',
+              },
+            },
+          },
+        }));
+        throw err;
+      });
+  }
+
+  async function ensurePeerConnection(ctx) {
+    runtime.lastCtx = ctx;
+    const state = normalizeState(ctx.getState());
+    if (runtime.peer) {
+      return runtime.peer;
+    }
+    if (!window.RTCPeerConnection) {
+      throw new Error('RTCPeerConnection not supported');
+    }
+    const peer = new RTCPeerConnection({
+      iceServers: state.iceServers,
+      iceTransportPolicy: 'relay',
+    });
+    runtime.peer = peer;
+    const dataChannel = peer.createDataChannel('chat', { ordered: true });
+    runtime.dataChannel = dataChannel;
+    setConnectionStatus('dc', 'connecting');
+
+    dataChannel.onopen = () => {
+      setConnectionStatus('dc', 'connected');
+    };
+    dataChannel.onclose = () => {
+      setConnectionStatus('dc', 'closed');
+    };
+    dataChannel.onerror = () => {
+      setConnectionStatus('dc', 'error');
+    };
+    dataChannel.onmessage = (event) => {
+      const payload = U.JSON.parseSafe(event.data, null);
+      if (payload && payload.kind === 'chat') {
+        appendChatMessage(payload.message);
+      }
+    };
+
+    peer.onicecandidate = (event) => {
+      if (event.candidate) {
+        sendIceCandidate(state, event.candidate).catch(() => {});
+      }
+    };
+
+    peer.ontrack = (event) => {
+      const [stream] = event.streams;
+      if (stream) {
+        attachRemoteStream(stream);
+      }
+    };
+
+    const local = await ensureLocalMedia(state);
+    local.getTracks().forEach((track) => peer.addTrack(track, local));
+
+    const offer = await peer.createOffer({ offerToReceiveAudio: true, offerToReceiveVideo: true });
+    await peer.setLocalDescription(offer);
+    await sendOfferToServer(state, offer);
+
+    runtime.signalQueue.forEach((signal) => {
+      if (signal.kind === 'answer' && signal.sdp) {
+        peer.setRemoteDescription(new RTCSessionDescription({ type: 'answer', sdp: signal.sdp })).catch(() => {});
+      }
+    });
+    runtime.signalQueue = [];
+    return peer;
+  }
+
+  async function acceptRemoteOffer(signal, state) {
+    if (!signal || !signal.sdp) return;
+    if (runtime.peer) {
+      runtime.peer.close();
+    }
+    const peer = new RTCPeerConnection({
+      iceServers: state.iceServers,
+      iceTransportPolicy: 'relay',
+    });
+    runtime.peer = peer;
+    peer.ondatachannel = (event) => {
+      runtime.dataChannel = event.channel;
+      runtime.dataChannel.onmessage = (ev) => {
+        const payload = U.JSON.parseSafe(ev.data, null);
+        if (payload && payload.kind === 'chat') {
+          appendChatMessage(payload.message);
+        }
+      };
+      runtime.dataChannel.onopen = () => setConnectionStatus('dc', 'connected');
+      runtime.dataChannel.onclose = () => setConnectionStatus('dc', 'closed');
+    };
+    peer.onicecandidate = (event) => {
+      if (event.candidate) {
+        sendIceCandidate(state, event.candidate).catch(() => {});
+      }
+    };
+    peer.ontrack = (event) => {
+      const [stream] = event.streams;
+      if (stream) attachRemoteStream(stream);
+    };
+    const local = await ensureLocalMedia(state);
+    local.getTracks().forEach((track) => peer.addTrack(track, local));
+    await peer.setRemoteDescription(new RTCSessionDescription({ type: 'offer', sdp: signal.sdp }));
+    const answer = await peer.createAnswer();
+    await peer.setLocalDescription(answer);
+    await sendAnswerToServer(state, answer);
+  }
+
+  function stopCall() {
+    if (runtime.recorder) {
+      runtime.recorder.stop();
+      runtime.recorder = null;
+    }
+    if (runtime.localStream) {
+      runtime.localStream.getTracks().forEach((track) => track.stop());
+    }
+    resetPeerState();
+    updateState((state) => ({
+      ...state,
+      data: {
+        ...state.data,
+        realtime: {
+          ...(state.data?.realtime || {}),
+          call: {
+            ...(state.data?.realtime?.call || {}),
+            status: 'idle',
+          },
+        },
+      },
+    }));
+  }
+
+  async function startCall(ctx) {
+    runtime.lastCtx = ctx;
+    const state = normalizeState(ctx.getState());
+    try {
+      await ensurePeerConnection(ctx);
+      updateState((s) => ({
+        ...s,
+        data: {
+          ...s.data,
+          realtime: {
+            ...(s.data?.realtime || {}),
+            call: {
+              ...(s.data?.realtime?.call || {}),
+              status: 'active',
+            },
+          },
+        },
+      }));
+    } catch (err) {
+      updateState((s) => ({
+        ...s,
+        data: {
+          ...s.data,
+          realtime: {
+            ...(s.data?.realtime || {}),
+            call: {
+              ...(s.data?.realtime?.call || {}),
+              status: 'error',
+              lastError: err?.message || 'Call setup failed',
+            },
+          },
+        },
+      }));
+    }
+  }
+
+  function toggleTrack(kind, enabled) {
+    const track = kind === 'audio' ? runtime.mediaTracks.audio : runtime.mediaTracks.video;
+    if (track) {
+      track.enabled = enabled;
+    }
+  }
+
+  function ensureRecorder(ctx) {
+    runtime.lastCtx = ctx;
+    if (runtime.recorder) {
+      return runtime.recorder;
+    }
+    const stream = runtime.localStream;
+    if (!stream) {
+      throw new Error('No local media stream');
+    }
+    const recorder = new MediaRecorder(stream, { mimeType: 'audio/webm' });
+    runtime.recorder = recorder;
+    runtime.recorderChunks = [];
+    recorder.ondataavailable = (event) => {
+      if (event.data && event.data.size) {
+        runtime.recorderChunks.push(event.data);
+      }
+    };
+    recorder.onstop = () => {
+      const blob = new Blob(runtime.recorderChunks, { type: 'audio/webm' });
+      runtime.recorderChunks = [];
+      updateState((state) => ({
+        ...state,
+        data: {
+          ...state.data,
+          realtime: {
+            ...(state.data?.realtime || {}),
+            voiceNote: {
+              ...(state.data?.realtime?.voiceNote || {}),
+              draft: blob,
+              recording: false,
+            },
+          },
+        },
+      }));
+    };
+    return recorder;
+  }
+
+  async function sendVoiceNote(ctx) {
+    runtime.lastCtx = ctx;
+    const stateRaw = ctx.getState();
+    const state = normalizeState(stateRaw);
+    const draft = stateRaw.data?.realtime?.voiceNote?.draft;
+    if (!draft) {
+      return;
+    }
+    const arrayBuffer = await draft.arrayBuffer();
+    const base64 = window.btoa(String.fromCharCode(...new Uint8Array(arrayBuffer)));
+    const message = encryptText('[voice-note]');
+    await postJSON(`${state.signalBase.replace(/\/$/, '')}/conversations/${encodeURIComponent(state.conversationId)}/voice-notes`, {
+      ciphertext: message.ciphertext,
+      keyId: message.keyId,
+      data: base64,
+      mimeType: draft.type || 'audio/webm',
+      metadata: { client: 'mishkah' },
+    }, getAuthHeaders(state));
+    updateState((s) => ({
+      ...s,
+      data: {
+        ...s.data,
+        realtime: {
+          ...(s.data?.realtime || {}),
+          voiceNote: {
+            ...(s.data?.realtime?.voiceNote || {}),
+            draft: null,
+          },
+        },
+      },
+    }));
+  }
+
+  function chatInputValue(state) {
+    return state.ui?.realtime?.chatInput || '';
+  }
+
+  function ChatMessagesList(db) {
+    const state = db.data?.realtime?.chat || {};
+    const messages = state.messages || [];
+    return D.Containers.Div({ attrs: { class: tw`flex flex-col gap-2 overflow-y-auto max-h-80 p-2 bg-slate-900/40 rounded-md` } }, [
+      D.Lists.Ul({ attrs: { class: tw`space-y-2` } }, messages.map((msg, idx) => (
+        D.Lists.Li({ attrs: { class: tw`flex flex-col gap-1 p-2 rounded-md bg-slate-800/70` } }, [
+          D.Text.Strong({}, [`#${msg.id || idx + 1}`]),
+          D.Text.P({}, [decryptText(msg.ciphertext || '')]),
+          msg.metadata && msg.metadata.voiceNote
+            ? D.Text.Span({ attrs: { class: tw`text-xs text-amber-300` } }, [`🎤 ${msg.metadata.voiceNote.mimeType || ''}`])
+            : null,
+        ])
+      )))
+    ]);
+  }
+
+  function ChatComposer(db) {
+    const inputId = 'chat-input-box';
+    const value = chatInputValue(db);
+    return D.Containers.Div({ attrs: { class: tw`flex flex-col gap-2` } }, [
+      D.Inputs.Textarea({
+        attrs: {
+          id: inputId,
+          class: tw`w-full rounded-md border border-slate-700 bg-slate-900/60 text-slate-100 p-2 min-h-[4rem]`,
+          placeholder: db.env.lang === 'ar' ? 'أكتب رسالة...' : 'Write a message…',
+          value,
+        },
+        events: {
+          input: { gkey: 'chat:input' },
+        },
+      }),
+      D.Containers.Div({ attrs: { class: tw`flex items-center gap-2` } }, [
+        D.Forms.Button({ attrs: { class: tw`px-4 py-2 bg-emerald-600 text-white rounded`, 'data-m-gkey': 'chat:send' } }, [
+          db.env.lang === 'ar' ? 'إرسال' : 'Send',
+        ]),
+        D.Forms.Button({ attrs: { class: tw`px-3 py-2 bg-slate-700 text-white rounded`, 'data-m-gkey': 'chat:ws:connect' } }, [
+          db.env.lang === 'ar' ? 'اتصال WS' : 'Connect WS',
+        ]),
+        D.Forms.Button({ attrs: { class: tw`px-3 py-2 bg-slate-700 text-white rounded`, 'data-m-gkey': 'chat:dc:ensure' } }, [
+          db.env.lang === 'ar' ? 'قناة البيانات' : 'Ensure DC',
+        ]),
+      ]),
+    ]);
+  }
+
+  function ChatPage(db) {
+    const conn = db.data?.realtime?.connection || {};
+    return D.Containers.Section({ attrs: { class: tw`space-y-4 p-4` } }, [
+      D.Text.H2({}, [db.env.lang === 'ar' ? 'الدردشة' : 'Chat']),
+      D.Containers.Div({ attrs: { class: tw`flex items-center gap-4 text-sm text-slate-300` } }, [
+        D.Text.Span({}, [`WS: ${conn.ws || 'idle'}`]),
+        D.Text.Span({}, [`DC: ${conn.dc || 'idle'}`]),
+      ]),
+      ChatMessagesList(db),
+      ChatComposer(db),
+    ]);
+  }
+
+  function CallPage(db) {
+    const call = db.data?.realtime?.call || {};
+    return D.Containers.Section({ attrs: { class: tw`grid gap-4 p-4 md:grid-cols-2` } }, [
+      D.Containers.Div({ attrs: { class: tw`space-y-3` } }, [
+        D.Text.H2({}, [db.env.lang === 'ar' ? 'المكالمة' : 'Call']),
+        D.Text.P({}, [call.status === 'active' ? 'Connected' : call.status || 'idle']),
+        D.Containers.Div({ attrs: { class: tw`flex items-center gap-2` } }, [
+          D.Forms.Button({ attrs: { class: tw`px-3 py-2 bg-emerald-600 text-white rounded`, 'data-m-gkey': 'call:start' } }, [
+            db.env.lang === 'ar' ? 'بدء' : 'Start',
+          ]),
+          D.Forms.Button({ attrs: { class: tw`px-3 py-2 bg-rose-600 text-white rounded`, 'data-m-gkey': 'call:end' } }, [
+            db.env.lang === 'ar' ? 'إنهاء' : 'End',
+          ]),
+          D.Forms.Button({ attrs: { class: tw`px-3 py-2 bg-slate-700 text-white rounded`, 'data-m-gkey': 'call:toggle-mic' } }, [
+            call.micEnabled === false ? (db.env.lang === 'ar' ? 'تشغيل المايك' : 'Unmute') : (db.env.lang === 'ar' ? 'كتم' : 'Mute'),
+          ]),
+          D.Forms.Button({ attrs: { class: tw`px-3 py-2 bg-slate-700 text-white rounded`, 'data-m-gkey': 'call:toggle-cam' } }, [
+            call.camEnabled === false ? (db.env.lang === 'ar' ? 'تشغيل الكاميرا' : 'Show Cam') : (db.env.lang === 'ar' ? 'إيقاف الكاميرا' : 'Hide Cam'),
+          ]),
+        ]),
+        D.Containers.Div({ attrs: { class: tw`flex items-center gap-2` } }, [
+          D.Forms.Button({ attrs: { class: tw`px-3 py-2 bg-amber-600 text-white rounded`, 'data-m-gkey': 'vn:record-toggle' } }, [
+            db.data?.realtime?.voiceNote?.recording ? (db.env.lang === 'ar' ? 'إيقاف التسجيل' : 'Stop Rec') : (db.env.lang === 'ar' ? 'تسجيل ملاحظة' : 'Record Note'),
+          ]),
+          D.Forms.Button({ attrs: { class: tw`px-3 py-2 bg-amber-700 text-white rounded`, 'data-m-gkey': 'vn:send' } }, [
+            db.env.lang === 'ar' ? 'إرسال الملاحظة' : 'Send Note',
+          ]),
+        ]),
+      ]),
+      D.Containers.Div({ attrs: { class: tw`grid gap-4` } }, [
+        D.Media.Video({ attrs: { id: 'realtime-local-video', autoplay: true, muted: true, playsinline: true, class: tw`w-full rounded-lg bg-slate-900 h-48 object-cover` } }),
+        D.Media.Video({ attrs: { id: 'realtime-remote-video', autoplay: true, playsinline: true, class: tw`w-full rounded-lg bg-slate-900 h-48 object-cover` } }),
+      ]),
+    ]);
+  }
+
+  const realtimeOrders = {
+    'chat:input': {
+      on: ['input'],
+      gkeys: ['chat:input'],
+      handler: (event, ctx) => {
+        runtime.lastCtx = ctx;
+        const value = event.target?.value || '';
+        ctx.setState((state) => ({
+          ...state,
+          ui: {
+            ...(state.ui || {}),
+            realtime: {
+              ...(state.ui?.realtime || {}),
+              chatInput: value,
+            },
+          },
+        }));
+        ctx.rebuild();
+      },
+    },
+    'chat:ws:connect': {
+      on: ['click'],
+      gkeys: ['chat:ws:connect'],
+      handler: (_event, ctx) => {
+        setupWebSocket(ctx);
+      },
+    },
+    'chat:dc:ensure': {
+      on: ['click'],
+      gkeys: ['chat:dc:ensure'],
+      handler: (_event, ctx) => {
+        ensurePeerConnection(ctx).catch(() => {
+          setConnectionStatus('dc', 'error');
+        });
+      },
+    },
+    'chat:send': {
+      on: ['click'],
+      gkeys: ['chat:send'],
+      handler: (_event, ctx) => {
+        runtime.lastCtx = ctx;
+        const state = ctx.getState();
+        const rt = normalizeState(state);
+        const value = chatInputValue(state);
+        if (!value) return;
+        const payload = encryptText(value);
+        const message = {
+          conversationId: rt.conversationId,
+          ciphertext: payload.ciphertext,
+          keyId: payload.keyId,
+          metadata: { via: rt.chat.transport || 'dc', ts: Date.now() },
+        };
+        if (runtime.dataChannel && runtime.dataChannel.readyState === 'open') {
+          runtime.dataChannel.send(JSON.stringify({ kind: 'chat', message }));
+          appendChatMessage(message);
+        } else {
+          setupWebSocket(ctx);
+          wsSend({
+            type: 'chat:send',
+            conversationId: rt.conversationId,
+            data: message,
+          });
+        }
+        ctx.setState((s) => ({
+          ...s,
+          ui: {
+            ...(s.ui || {}),
+            realtime: {
+              ...(s.ui?.realtime || {}),
+              chatInput: '',
+            },
+          },
+        }));
+        ctx.rebuild();
+      },
+    },
+    'call:start': {
+      on: ['click'],
+      gkeys: ['call:start'],
+      handler: (_event, ctx) => {
+        setupWebSocket(ctx);
+        startCall(ctx);
+      },
+    },
+    'call:end': {
+      on: ['click'],
+      gkeys: ['call:end'],
+      handler: () => {
+        stopCall();
+      },
+    },
+    'call:toggle-mic': {
+      on: ['click'],
+      gkeys: ['call:toggle-mic'],
+      handler: (_event, ctx) => {
+        runtime.lastCtx = ctx;
+        ctx.setState((state) => {
+          const enabled = !(state.data?.realtime?.call?.micEnabled === false);
+          toggleTrack('audio', !enabled);
+          return {
+            ...state,
+            data: {
+              ...state.data,
+              realtime: {
+                ...(state.data?.realtime || {}),
+                call: {
+                  ...(state.data?.realtime?.call || {}),
+                  micEnabled: !enabled,
+                },
+              },
+            },
+          };
+        });
+        ctx.rebuild();
+      },
+    },
+    'call:toggle-cam': {
+      on: ['click'],
+      gkeys: ['call:toggle-cam'],
+      handler: (_event, ctx) => {
+        runtime.lastCtx = ctx;
+        ctx.setState((state) => {
+          const enabled = !(state.data?.realtime?.call?.camEnabled === false);
+          toggleTrack('video', !enabled);
+          return {
+            ...state,
+            data: {
+              ...state.data,
+              realtime: {
+                ...(state.data?.realtime || {}),
+                call: {
+                  ...(state.data?.realtime?.call || {}),
+                  camEnabled: !enabled,
+                },
+              },
+            },
+          };
+        });
+        ctx.rebuild();
+      },
+    },
+    'vn:record-toggle': {
+      on: ['click'],
+      gkeys: ['vn:record-toggle'],
+      handler: (_event, ctx) => {
+        runtime.lastCtx = ctx;
+        const state = ctx.getState();
+        const recording = state.data?.realtime?.voiceNote?.recording;
+        if (recording && runtime.recorder) {
+          runtime.recorder.stop();
+          return;
+        }
+        ensureRecorder(ctx);
+        if (runtime.recorder) {
+          runtime.recorder.start();
+          ctx.setState((s) => ({
+            ...s,
+            data: {
+              ...s.data,
+              realtime: {
+                ...(s.data?.realtime || {}),
+                voiceNote: {
+                  ...(s.data?.realtime?.voiceNote || {}),
+                  recording: true,
+                },
+              },
+            },
+          }));
+          ctx.rebuild();
+        }
+      },
+    },
+    'vn:send': {
+      on: ['click'],
+      gkeys: ['vn:send'],
+      handler: (_event, ctx) => {
+        sendVoiceNote(ctx).catch(() => {
+          updateState((s) => ({
+            ...s,
+            data: {
+              ...s.data,
+              realtime: {
+                ...(s.data?.realtime || {}),
+                voiceNote: {
+                  ...(s.data?.realtime?.voiceNote || {}),
+                  lastError: 'Failed to send voice note',
+                },
+              },
+            },
+          }));
+        });
+      },
+    },
+  };
+
+  function createRealtimeApp(options) {
+    const cfg = options || {};
+    const database = {
+      template: cfg.template || 'PagesShell',
+      theme: cfg.theme || 'dark',
+      env: { theme: cfg.theme || 'dark', lang: cfg.lang || 'ar', dir: cfg.lang === 'en' ? 'ltr' : 'rtl' },
+      pages: [
+        { key: 'chat', icon: '💬', label: { ar: 'دردشة', en: 'Chat' }, dsl: ChatPage },
+        { key: 'call', icon: '🎥', label: { ar: 'مكالمة', en: 'Call' }, dsl: CallPage },
+      ],
+      data: {
+        realtime: {
+          conversationId: cfg.conversationId || DEFAULT_CONVERSATION,
+          signalBase: cfg.signalBase || DEFAULT_SIGNAL_BASE,
+          wsUrl: cfg.wsUrl || DEFAULT_WS_URL,
+          token: cfg.token || null,
+          chat: { messages: [], transport: 'dc' },
+          connection: { ws: 'idle', dc: 'idle' },
+          call: { status: 'idle', micEnabled: true, camEnabled: true },
+          voiceNote: { recording: false, draft: null },
+          iceServers: cfg.iceServers || [],
+        },
+      },
+      ui: {
+        realtime: { chatInput: '' },
+      },
+    };
+
+    const app = M.Pages.createV2({
+      ...database,
+      orders: realtimeOrders,
+    });
+    runtime.app = app;
+    return app;
+  }
+
+  M.Realtime = {
+    create: createRealtimeApp,
+    orders: realtimeOrders,
+    encryptText,
+    decryptText,
+  };
+})(typeof window !== 'undefined' ? window : this);

--- a/ws/package.json
+++ b/ws/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "ioredis": "^5.4.1",
     "jsonwebtoken": "^9.0.2",
+    "pg": "^8.11.5",
     "pino": "^9.0.0",
     "uWebSockets.js": "uNetworking/uWebSockets.js#v20.45.0",
     "zod": "^3.23.8"

--- a/ws/src/index.js
+++ b/ws/src/index.js
@@ -4,6 +4,8 @@ import Redis from 'ioredis';
 import pino from 'pino';
 import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
+import { ChatStore } from './services/chat-store.js';
+import { VoiceNoteStore } from './services/voice-note-store.js';
 
 /**
  * ------------------------------------------------------------
@@ -17,14 +19,19 @@ const envSchema = z.object({
   JWT_SECRET: z.string().min(16).optional(),
   REQUIRE_AUTH_SUBSCRIBE: z.coerce.boolean().default(true),
   REQUIRE_AUTH_PUBLISH: z.coerce.boolean().default(true),
-  ALLOWED_SUBSCRIBE: z.string().default('^(app|pos|kds|ui):[a-z0-9:_-]+$'),
-  ALLOWED_PUBLISH: z.string().default('^(app|pos|kds|ui):[a-z0-9:_-]+$'),
+  ALLOWED_SUBSCRIBE: z.string().default('^(app|pos|kds|ui|chat|rtc):[a-z0-9:_-]+$'),
+  ALLOWED_PUBLISH: z.string().default('^(app|pos|kds|ui|chat|rtc):[a-z0-9:_-]+$'),
   MAX_PAYLOAD_BYTES: z.coerce.number().int().positive().default(1024 * 1024),
   MAX_BACKPRESSURE_BYTES: z.coerce.number().int().positive().default(1024 * 1024),
   IDLE_TIMEOUT_SECS: z.coerce.number().int().min(1).default(60),
   MESSAGES_PER_10S: z.coerce.number().int().min(1).default(200),
   REDIS_URL: z.string().url().default('redis://redis:6379'),
   REDIS_PREFIX: z.string().default('t:'),
+  PG_URL: z.string().url().optional(),
+  VOICE_NOTES_DIR: z.string().default('/tmp/mishkah/voice-notes'),
+  API_REQUIRE_AUTH: z.coerce.boolean().default(true),
+  RTC_SIGNAL_PREFIX: z.string().default('rtc:'),
+  RTC_SIGNAL_TTL_SECS: z.coerce.number().int().min(5).default(120),
   LOG_LEVEL: z.string().default('info'),
 });
 
@@ -52,6 +59,11 @@ const config = {
   messagesPer10s: parsedEnv.MESSAGES_PER_10S,
   redisUrl: parsedEnv.REDIS_URL,
   redisPrefix: parsedEnv.REDIS_PREFIX,
+  pgUrl: parsedEnv.PG_URL || null,
+  voiceNotesDir: parsedEnv.VOICE_NOTES_DIR,
+  apiRequireAuth: parsedEnv.API_REQUIRE_AUTH,
+  rtcSignalPrefix: parsedEnv.RTC_SIGNAL_PREFIX,
+  rtcSignalTtlSecs: parsedEnv.RTC_SIGNAL_TTL_SECS,
   logLevel: parsedEnv.LOG_LEVEL,
 };
 
@@ -60,6 +72,27 @@ const log = pino({
   base: undefined,
   redact: ['req.headers.authorization', 'token'],
 });
+
+const STATUS_TEXT = {
+  200: 'OK',
+  201: 'Created',
+  202: 'Accepted',
+  204: 'No Content',
+  400: 'Bad Request',
+  401: 'Unauthorized',
+  403: 'Forbidden',
+  404: 'Not Found',
+  409: 'Conflict',
+  422: 'Unprocessable Entity',
+  429: 'Too Many Requests',
+  500: 'Internal Server Error',
+};
+
+const chatStore = new ChatStore({ connectionString: config.pgUrl, log });
+await chatStore.init();
+
+const voiceNoteStore = new VoiceNoteStore({ directory: config.voiceNotesDir, log });
+await voiceNoteStore.init();
 
 function safeRegex(pattern, label) {
   try {
@@ -72,6 +105,42 @@ function safeRegex(pattern, label) {
 
 config.subscribeRegex = safeRegex(parsedEnv.ALLOWED_SUBSCRIBE, 'subscribe');
 config.publishRegex = safeRegex(parsedEnv.ALLOWED_PUBLISH, 'publish');
+
+const rtcOfferSchema = z.object({
+  sdp: z.string().min(10),
+  meta: z.record(z.any()).optional(),
+  candidates: z.array(z.string()).optional(),
+});
+
+const rtcAnswerSchema = z.object({
+  sdp: z.string().min(10),
+  meta: z.record(z.any()).optional(),
+  candidates: z.array(z.string()).optional(),
+});
+
+const rtcIceSchema = z.object({
+  candidate: z.string().nullable().optional(),
+  sdpMid: z.string().nullable().optional(),
+  sdpMLineIndex: z.coerce.number().int().nullable().optional(),
+  meta: z.record(z.any()).optional(),
+});
+
+const chatSendSchema = z.object({
+  ciphertext: z.string().min(1),
+  keyId: z.string().optional(),
+  ttlSeconds: z.number().int().min(1).max(60 * 60 * 24).optional(),
+  metadata: z.record(z.any()).optional(),
+});
+
+const voiceNotePayloadSchema = z.object({
+  ciphertext: z.string().min(1),
+  keyId: z.string().optional(),
+  data: z.string().min(1),
+  mimeType: z.string().optional(),
+  durationMs: z.number().int().min(0).optional(),
+  ttlSeconds: z.number().int().min(1).max(60 * 60 * 24).optional(),
+  metadata: z.record(z.any()).optional(),
+});
 
 /**
  * ------------------------------------------------------------
@@ -138,6 +207,263 @@ function rateLimitExceeded(state) {
   return state.count > config.messagesPer10s;
 }
 
+function jsonResponse(res, status, payload = {}) {
+  const text = STATUS_TEXT[status] || 'OK';
+  res.writeStatus(`${status} ${text}`);
+  res.writeHeader('content-type', 'application/json');
+  res.end(JSON.stringify(payload));
+}
+
+function errorResponse(res, status, message, extra) {
+  jsonResponse(res, status, { error: true, message, ...(extra || {}) });
+}
+
+function readJsonBody(res, schema, handler) {
+  let buffer = Buffer.alloc(0);
+  let aborted = false;
+  res.onAborted(() => {
+    aborted = true;
+  });
+  res.onData((chunk, isLast) => {
+    if (aborted) return;
+    buffer = Buffer.concat([buffer, Buffer.from(chunk)]);
+    if (!isLast) {
+      return;
+    }
+    let parsed;
+    try {
+      parsed = buffer.length ? JSON.parse(buffer.toString('utf8')) : {};
+    } catch (err) {
+      errorResponse(res, 400, 'Invalid JSON payload');
+      return;
+    }
+    let validated = parsed;
+    if (schema) {
+      try {
+        validated = schema.parse(parsed);
+      } catch (err) {
+        errorResponse(res, 422, 'Payload validation failed', { issues: err.errors ?? err });
+        return;
+      }
+    }
+    Promise.resolve(handler(validated))
+      .catch((err) => {
+        log.error({ err }, 'HTTP handler error');
+        if (!aborted) {
+          errorResponse(res, 500, 'Internal server error');
+        }
+      });
+  });
+}
+
+function handleAsync(res, handler) {
+  let aborted = false;
+  res.onAborted(() => {
+    aborted = true;
+  });
+  Promise.resolve()
+    .then(() => handler(() => aborted))
+    .catch((err) => {
+      log.error({ err }, 'HTTP handler error');
+      if (!aborted) {
+        errorResponse(res, 500, 'Internal server error');
+      }
+    });
+}
+
+function authenticateRequest(req) {
+  const authHeader = req.getHeader('authorization') || '';
+  const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7).trim() : null;
+  return verifyToken(token);
+}
+
+function normalizeUserClaims(claims) {
+  if (!claims) return null;
+  return { id: claims.sub ?? claims.id ?? null, roles: claims.roles ?? [], claims };
+}
+
+function requireHttpUser(req, res) {
+  if (!config.apiRequireAuth) {
+    return { id: null, roles: [], claims: null };
+  }
+  const claims = authenticateRequest(req);
+  if (!claims) {
+    errorResponse(res, 401, 'Authentication required');
+    return null;
+  }
+  return normalizeUserClaims(claims);
+}
+
+function signalTopic(conversationId) {
+  return `${config.rtcSignalPrefix}${conversationId}`;
+}
+
+function enforceRelayOnlySdp(sdp) {
+  if (!sdp) return sdp;
+  return sdp
+    .split(/\r?\n/)
+    .filter((line) => !line.startsWith('a=candidate:') || line.includes(' typ relay'))
+    .join('\r\n');
+}
+
+function isRelayCandidate(candidate) {
+  if (candidate == null || candidate === '') return true;
+  return / typ relay( |$)/.test(candidate);
+}
+
+function filterRelayCandidates(candidates = []) {
+  return candidates.filter((c) => isRelayCandidate(c));
+}
+
+function broadcastTopic(topic, data, meta = {}) {
+  const envelope = {
+    type: 'publish',
+    topic,
+    data,
+    meta: { ...meta, ts: meta.ts || nowTs() },
+  };
+  const serialized = JSON.stringify(envelope);
+  log.debug({ topic }, 'Broadcast topic');
+  app.publish(topic, serialized);
+  redisPub
+    .publish(`${config.redisPrefix}${topic}`, serialized)
+    .catch((err) => log.error({ err, topic }, 'Failed to publish to Redis'));
+  return envelope;
+}
+
+async function storeAndFanOutMessage({ conversationId, senderId, ciphertext, keyId, ttlSeconds, metadata }) {
+  const persisted = await chatStore.saveMessage({
+    conversationId,
+    senderId,
+    ciphertext,
+    keyId,
+    ttlSeconds,
+    metadata,
+  });
+  const payload = {
+    id: persisted.id,
+    conversationId,
+    ciphertext,
+    keyId: keyId || null,
+    metadata: metadata || null,
+    createdAt: persisted.createdAt,
+    expiresAt: persisted.expiresAt,
+  };
+  broadcastTopic(`chat:${conversationId}`, payload, { from: senderId, ttlSeconds });
+  return payload;
+}
+
+async function handleVoiceNote({ conversationId, senderId, ciphertext, keyId, mimeType, durationMs, ttlSeconds, metadata, data }) {
+  const buffer = Buffer.from(data, 'base64');
+  if (!buffer.length) {
+    throw new Error('Voice note payload is empty');
+  }
+  const stored = await voiceNoteStore.save({
+    buffer,
+    mimeType: mimeType || 'audio/webm',
+    conversationId,
+    senderId,
+    durationMs,
+  });
+  await chatStore.recordVoiceNote({
+    voiceNoteId: stored.id,
+    conversationId,
+    senderId,
+    storagePath: stored.path,
+    mimeType: stored.mimeType,
+    sizeBytes: stored.sizeBytes,
+    durationMs: stored.durationMs,
+  });
+  const enrichedMeta = {
+    ...(metadata || {}),
+    voiceNote: {
+      id: stored.id,
+      mimeType: stored.mimeType,
+      durationMs: stored.durationMs,
+      sizeBytes: stored.sizeBytes,
+      fileName: stored.fileName,
+    },
+  };
+  const message = await storeAndFanOutMessage({
+    conversationId,
+    senderId,
+    ciphertext,
+    keyId,
+    ttlSeconds,
+    metadata: enrichedMeta,
+  });
+  return { voiceNote: stored, message };
+}
+
+async function processChatSend(ws, envelope) {
+  const conversationId = envelope.conversationId || envelope.topic;
+  if (!conversationId) {
+    sendJSON(ws, { type: 'error', code: 'conversation_required', message: 'conversationId is required.' });
+    return;
+  }
+  if (config.requireAuthPub && !ws.user) {
+    sendJSON(ws, { type: 'error', code: 'unauthorized_pub', message: 'Authentication required before publishing.' });
+    return;
+  }
+  const parsed = chatSendSchema.safeParse(envelope.data || envelope.payload || {});
+  if (!parsed.success) {
+    sendJSON(ws, { type: 'error', code: 'invalid_payload', message: 'Invalid chat payload.', issues: parsed.error.issues });
+    return;
+  }
+  try {
+    const message = await storeAndFanOutMessage({
+      conversationId,
+      senderId: ws.user?.id ?? null,
+      ciphertext: parsed.data.ciphertext,
+      keyId: parsed.data.keyId,
+      ttlSeconds: parsed.data.ttlSeconds,
+      metadata: parsed.data.metadata,
+    });
+    sendJSON(ws, {
+      type: 'ack',
+      event: 'chat:send',
+      conversationId,
+      message,
+      ts: nowTs(),
+    });
+  } catch (err) {
+    log.error({ err, conversationId }, 'Failed to persist message from WS');
+    sendJSON(ws, { type: 'error', code: 'chat_store_failed', message: 'Failed to store message.' });
+  }
+}
+
+async function processChatHistory(ws, envelope) {
+  const conversationId = envelope.conversationId || envelope.topic;
+  if (!conversationId) {
+    sendJSON(ws, { type: 'error', code: 'conversation_required', message: 'conversationId is required.' });
+    return;
+  }
+  if (config.requireAuthSub && !ws.user) {
+    sendJSON(ws, { type: 'error', code: 'unauthorized', message: 'Authentication required.' });
+    return;
+  }
+  const limitRaw = envelope.limit ?? envelope.data?.limit ?? 50;
+  const beforeRaw = envelope.before ?? envelope.data?.before ?? null;
+  const limit = Number.isFinite(Number(limitRaw)) ? Math.max(1, Math.min(Number(limitRaw), 200)) : 50;
+  const beforeDate = beforeRaw ? new Date(beforeRaw) : null;
+  try {
+    const messages = await chatStore.listMessages({
+      conversationId,
+      limit,
+      before: beforeDate && !Number.isNaN(beforeDate.getTime()) ? beforeDate : null,
+    });
+    sendJSON(ws, {
+      type: 'chat:history',
+      conversationId,
+      messages,
+      ts: nowTs(),
+    });
+  } catch (err) {
+    log.error({ err, conversationId }, 'Failed to load chat history');
+    sendJSON(ws, { type: 'error', code: 'chat_history_failed', message: 'Failed to load messages.' });
+  }
+}
+
 /**
  * ------------------------------------------------------------
  * uWebSockets App
@@ -198,6 +524,167 @@ app.get('/healthz', (res) => {
   res.end(JSON.stringify({ status: 'ok', now: nowTs() }));
 });
 
+app.post('/api/rtc/:conversationId/offer', (res, req) => {
+  const conversationId = req.getParameter(0);
+  if (!conversationId) {
+    errorResponse(res, 400, 'Conversation id is required');
+    return;
+  }
+  const user = requireHttpUser(req, res);
+  if (!user) return;
+  readJsonBody(res, rtcOfferSchema, async (body) => {
+    try {
+      const sanitizedSdp = enforceRelayOnlySdp(body.sdp);
+      const candidates = filterRelayCandidates(body.candidates || []);
+      broadcastTopic(
+        signalTopic(conversationId),
+        { kind: 'offer', sdp: sanitizedSdp, candidates },
+        { ...(body.meta || {}), from: user.id, ttlSeconds: config.rtcSignalTtlSecs },
+      );
+      jsonResponse(res, 202, { status: 'accepted' });
+    } catch (err) {
+      log.error({ err, conversationId }, 'Failed to handle RTC offer');
+      errorResponse(res, 500, 'Failed to handle offer');
+    }
+  });
+});
+
+app.post('/api/rtc/:conversationId/answer', (res, req) => {
+  const conversationId = req.getParameter(0);
+  if (!conversationId) {
+    errorResponse(res, 400, 'Conversation id is required');
+    return;
+  }
+  const user = requireHttpUser(req, res);
+  if (!user) return;
+  readJsonBody(res, rtcAnswerSchema, async (body) => {
+    try {
+      const sanitizedSdp = enforceRelayOnlySdp(body.sdp);
+      const candidates = filterRelayCandidates(body.candidates || []);
+      broadcastTopic(
+        signalTopic(conversationId),
+        { kind: 'answer', sdp: sanitizedSdp, candidates },
+        { ...(body.meta || {}), from: user.id, ttlSeconds: config.rtcSignalTtlSecs },
+      );
+      jsonResponse(res, 202, { status: 'accepted' });
+    } catch (err) {
+      log.error({ err, conversationId }, 'Failed to handle RTC answer');
+      errorResponse(res, 500, 'Failed to handle answer');
+    }
+  });
+});
+
+app.post('/api/rtc/:conversationId/ice', (res, req) => {
+  const conversationId = req.getParameter(0);
+  if (!conversationId) {
+    errorResponse(res, 400, 'Conversation id is required');
+    return;
+  }
+  const user = requireHttpUser(req, res);
+  if (!user) return;
+  readJsonBody(res, rtcIceSchema, async (body) => {
+    try {
+      if (body.candidate && !isRelayCandidate(body.candidate)) {
+        errorResponse(res, 422, 'Only relay ICE candidates are permitted');
+        return;
+      }
+      broadcastTopic(
+        signalTopic(conversationId),
+        {
+          kind: 'ice',
+          candidate: body.candidate ?? null,
+          sdpMid: body.sdpMid ?? null,
+          sdpMLineIndex: body.sdpMLineIndex ?? null,
+        },
+        { ...(body.meta || {}), from: user.id, ttlSeconds: config.rtcSignalTtlSecs },
+      );
+      jsonResponse(res, 202, { status: 'accepted' });
+    } catch (err) {
+      log.error({ err, conversationId }, 'Failed to handle ICE candidate');
+      errorResponse(res, 500, 'Failed to handle candidate');
+    }
+  });
+});
+
+app.get('/api/conversations/:conversationId/messages', (res, req) => {
+  const conversationId = req.getParameter(0);
+  if (!conversationId) {
+    errorResponse(res, 400, 'Conversation id is required');
+    return;
+  }
+  const user = requireHttpUser(req, res);
+  if (!user) return;
+  handleAsync(res, async (isAborted) => {
+    const limitParam = parseInt(req.getQuery('limit') || '50', 10);
+    const limit = Number.isFinite(limitParam) ? Math.max(1, Math.min(limitParam, 200)) : 50;
+    const beforeRaw = req.getQuery('before') || null;
+    const before = beforeRaw ? new Date(beforeRaw) : null;
+    const messages = await chatStore.listMessages({
+      conversationId,
+      limit,
+      before: before && !Number.isNaN(before.getTime()) ? before : null,
+    });
+    if (!isAborted()) {
+      jsonResponse(res, 200, { messages });
+    }
+  });
+});
+
+app.post('/api/conversations/:conversationId/messages', (res, req) => {
+  const conversationId = req.getParameter(0);
+  if (!conversationId) {
+    errorResponse(res, 400, 'Conversation id is required');
+    return;
+  }
+  const user = requireHttpUser(req, res);
+  if (!user) return;
+  readJsonBody(res, chatSendSchema, async (body) => {
+    try {
+      const message = await storeAndFanOutMessage({
+        conversationId,
+        senderId: user.id,
+        ciphertext: body.ciphertext,
+        keyId: body.keyId,
+        ttlSeconds: body.ttlSeconds,
+        metadata: body.metadata,
+      });
+      jsonResponse(res, 201, { message });
+    } catch (err) {
+      log.error({ err, conversationId }, 'Failed to persist message');
+      errorResponse(res, 500, 'Failed to store message');
+    }
+  });
+});
+
+app.post('/api/conversations/:conversationId/voice-notes', (res, req) => {
+  const conversationId = req.getParameter(0);
+  if (!conversationId) {
+    errorResponse(res, 400, 'Conversation id is required');
+    return;
+  }
+  const user = requireHttpUser(req, res);
+  if (!user) return;
+  readJsonBody(res, voiceNotePayloadSchema, async (body) => {
+    try {
+      const result = await handleVoiceNote({
+        conversationId,
+        senderId: user.id,
+        ciphertext: body.ciphertext,
+        keyId: body.keyId,
+        mimeType: body.mimeType,
+        durationMs: body.durationMs,
+        ttlSeconds: body.ttlSeconds,
+        metadata: body.metadata,
+        data: body.data,
+      });
+      jsonResponse(res, 201, result);
+    } catch (err) {
+      log.error({ err, conversationId }, 'Failed to process voice note');
+      errorResponse(res, 500, 'Failed to process voice note');
+    }
+  });
+});
+
 app.ws('/*', {
   compression: uWS.DEDICATED_COMPRESSOR_256KB,
   maxPayloadLength: config.maxPayloadBytes,
@@ -240,7 +727,18 @@ app.ws('/*', {
       return;
     }
 
-    handleMessage(ws, payload);
+    try {
+      const maybePromise = handleMessage(ws, payload);
+      if (maybePromise && typeof maybePromise.then === 'function') {
+        maybePromise.catch((err) => {
+          log.error({ err }, 'Async handler failed');
+          sendJSON(ws, { type: 'error', code: 'internal_error', message: 'Internal error processing message.' });
+        });
+      }
+    } catch (err) {
+      log.error({ err }, 'Failed to handle message');
+      sendJSON(ws, { type: 'error', code: 'internal_error', message: 'Internal error processing message.' });
+    }
   },
   drain: () => {
     // no-op: we do not queue messages, but handler required for observability
@@ -251,7 +749,7 @@ app.ws('/*', {
   },
 });
 
-function handleMessage(ws, envelope) {
+async function handleMessage(ws, envelope) {
   const { type, topic, data, meta } = envelope;
 
   if (!type || typeof type !== 'string') {
@@ -266,6 +764,14 @@ function handleMessage(ws, envelope) {
 
     case 'auth':
       handleAuth(ws, envelope);
+      break;
+
+    case 'chat:send':
+      await processChatSend(ws, envelope);
+      break;
+
+    case 'chat:history':
+      await processChatHistory(ws, envelope);
       break;
 
     case 'subscribe':
@@ -320,35 +826,17 @@ function handleAuth(ws, envelope) {
     sendJSON(ws, { type: 'error', code: 'token_required', message: 'Authentication token is required.' });
     return;
   }
-  const user = verifyToken(token);
-  if (!user) {
+  const claims = verifyToken(token);
+  if (!claims) {
     sendJSON(ws, { type: 'error', code: 'auth_failed', message: 'Invalid or expired token.' });
     return;
   }
-  ws.user = { id: user.sub ?? user.id ?? null, roles: user.roles ?? [], claims: user };
+  ws.user = normalizeUserClaims(claims);
   sendJSON(ws, { type: 'ack', event: 'auth', user: ws.user, ts: nowTs() });
 }
 
 function publishMessage(ws, { topic, data, meta }) {
-  const envelope = {
-    type: 'publish',
-    topic,
-    data,
-    meta: {
-      ...(meta || {}),
-      from: ws.user?.id ?? null,
-      ts: nowTs(),
-    },
-  };
-  const serialized = JSON.stringify(envelope);
-
-  log.debug({ topic }, 'Local publish');
-  app.publish(topic, serialized);
-
-  redisPub
-    .publish(`${config.redisPrefix}${topic}`, serialized)
-    .catch((err) => log.error({ err, topic }, 'Failed to publish to Redis'));
-
+  broadcastTopic(topic, data, { ...(meta || {}), from: ws.user?.id ?? null });
   sendJSON(ws, { type: 'ack', event: 'publish', topic, ts: nowTs() });
 }
 
@@ -381,6 +869,7 @@ function shutdown(signal) {
   }
   redisSub.quit().catch((err) => log.error({ err }, 'Error quitting Redis subscriber'));
   redisPub.quit().catch((err) => log.error({ err }, 'Error quitting Redis publisher'));
+  chatStore.close().catch((err) => log.error({ err }, 'Error closing chat store'));
   setTimeout(() => process.exit(0), 500).unref();
 }
 

--- a/ws/src/services/chat-store.js
+++ b/ws/src/services/chat-store.js
@@ -1,0 +1,147 @@
+import { Pool } from 'pg';
+import { randomUUID } from 'node:crypto';
+
+export class ChatStore {
+  constructor({ connectionString, log }) {
+    this.log = log;
+    this.pool = connectionString ? new Pool({ connectionString }) : null;
+    this.memory = new Map();
+  }
+
+  async init() {
+    if (!this.pool) {
+      this.log?.warn('ChatStore running in memory-only mode');
+      return;
+    }
+    // Ensure connection works early.
+    try {
+      await this.pool.query('SELECT 1');
+      this.log?.info('Connected to PostgreSQL for ChatStore');
+    } catch (err) {
+      this.log?.error({ err }, 'Failed to connect to PostgreSQL, falling back to memory mode');
+      await this.pool?.end?.();
+      this.pool = null;
+    }
+  }
+
+  async saveMessage({ conversationId, senderId, ciphertext, keyId, ttlSeconds = null, metadata = null }) {
+    if (!conversationId || !ciphertext) {
+      throw new Error('conversationId and ciphertext are required');
+    }
+    const messageId = randomUUID();
+    const createdAt = new Date();
+    const expiresAt = ttlSeconds ? new Date(createdAt.getTime() + ttlSeconds * 1000) : null;
+
+    if (!this.pool) {
+      const bucket = this.memory.get(conversationId) || [];
+      bucket.push({
+        id: messageId,
+        conversation_id: conversationId,
+        sender_id: senderId || null,
+        ciphertext,
+        key_id: keyId || null,
+        metadata: metadata || null,
+        created_at: createdAt.toISOString(),
+        expires_at: expiresAt ? expiresAt.toISOString() : null,
+      });
+      this.memory.set(conversationId, bucket);
+      return { id: messageId, createdAt, expiresAt };
+    }
+
+    const query = `
+      INSERT INTO messages (id, conversation_id, sender_id, ciphertext, key_id, metadata, expires_at)
+      VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7)
+      RETURNING id, created_at, expires_at
+    `;
+    const values = [
+      messageId,
+      conversationId,
+      senderId || null,
+      ciphertext,
+      keyId || null,
+      metadata ? JSON.stringify(metadata) : null,
+      expiresAt,
+    ];
+
+    const res = await this.pool.query(query, values);
+    return {
+      id: res.rows[0].id,
+      createdAt: res.rows[0].created_at,
+      expiresAt: res.rows[0].expires_at,
+    };
+  }
+
+  async listMessages({ conversationId, limit = 50, before }) {
+    if (!conversationId) return [];
+
+    if (!this.pool) {
+      const bucket = this.memory.get(conversationId) || [];
+      const sorted = bucket
+        .filter((m) => !m.expires_at || new Date(m.expires_at) > new Date())
+        .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+      return sorted.slice(0, limit).reverse();
+    }
+
+    const res = await this.pool.query(
+      `
+        SELECT id, conversation_id, sender_id, ciphertext, key_id, metadata, created_at, expires_at
+        FROM messages
+        WHERE conversation_id = $1
+          AND ($2::timestamptz IS NULL OR created_at < $2)
+          AND (expires_at IS NULL OR expires_at > NOW())
+        ORDER BY created_at DESC
+        LIMIT $3
+      `,
+      [conversationId, before || null, limit],
+    );
+    return res.rows.reverse();
+  }
+
+  async recordVoiceNote({
+    voiceNoteId = randomUUID(),
+    conversationId,
+    senderId,
+    storagePath,
+    mimeType,
+    sizeBytes,
+    durationMs,
+  }) {
+    if (!conversationId || !storagePath) {
+      throw new Error('conversationId and storagePath are required');
+    }
+
+    if (!this.pool) {
+      const bucket = this.memory.get(`vn:${conversationId}`) || [];
+      const row = {
+        id: voiceNoteId,
+        conversation_id: conversationId,
+        sender_id: senderId || null,
+        storage_path: storagePath,
+        mime_type: mimeType || 'audio/webm',
+        size_bytes: sizeBytes || 0,
+        duration_ms: durationMs || null,
+        created_at: new Date().toISOString(),
+      };
+      bucket.push(row);
+      this.memory.set(`vn:${conversationId}`, bucket);
+      return row;
+    }
+
+    const res = await this.pool.query(
+      `
+        INSERT INTO voice_notes (id, conversation_id, sender_id, storage_path, mime_type, size_bytes, duration_ms)
+        VALUES ($1, $2, $3, $4, $5, $6, $7)
+        RETURNING id, conversation_id, sender_id, storage_path, mime_type, size_bytes, duration_ms, created_at
+      `,
+      [voiceNoteId, conversationId, senderId || null, storagePath, mimeType || 'audio/webm', sizeBytes || 0, durationMs || null],
+    );
+    return res.rows[0];
+  }
+
+  async close() {
+    if (this.pool) {
+      await this.pool.end();
+    }
+    this.memory.clear();
+  }
+}

--- a/ws/src/services/voice-note-store.js
+++ b/ws/src/services/voice-note-store.js
@@ -1,0 +1,49 @@
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+export class VoiceNoteStore {
+  constructor({ directory, log }) {
+    this.dir = directory;
+    this.log = log;
+  }
+
+  async init() {
+    if (!this.dir) {
+      throw new Error('VoiceNoteStore requires a directory');
+    }
+    await fs.mkdir(this.dir, { recursive: true });
+    this.log?.info({ dir: this.dir }, 'Voice note storage initialized');
+  }
+
+  async save({ buffer, mimeType = 'audio/webm', conversationId, senderId, durationMs }) {
+    if (!buffer || !Buffer.isBuffer(buffer)) {
+      throw new Error('VoiceNoteStore.save requires a buffer');
+    }
+    const voiceNoteId = randomUUID();
+    const fileName = `${voiceNoteId}.bin`;
+    const filePath = join(this.dir, fileName);
+    await fs.writeFile(filePath, buffer);
+    return {
+      id: voiceNoteId,
+      path: filePath,
+      fileName,
+      mimeType,
+      conversationId,
+      senderId,
+      durationMs: durationMs || null,
+      sizeBytes: buffer.byteLength,
+    };
+  }
+
+  async remove(filePath) {
+    if (!filePath) return;
+    try {
+      await fs.unlink(filePath);
+    } catch (err) {
+      if (err.code !== 'ENOENT') {
+        this.log?.warn({ err, filePath }, 'Failed to delete voice note');
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- extend the WebSocket gateway with Redis-backed signaling routes, relay-only ICE enforcement, and store-and-forward messaging/voice note handling
- introduce PostgreSQL chat/voice note services plus voice note storage helpers for filesystem persistence
- scaffold a Mishkah realtime UI module with chat, call, and voice note controls wired to WebRTC/DataChannel and WebSocket fallbacks

## Testing
- node --check ws/src/index.js
- node --check mishkah.pages.realtime.js

------
https://chatgpt.com/codex/tasks/task_e_68e5e524a40c8333b69480b427e9245b