### PR TITLE
Add ERD sidebar toggles and improve canvas interactions

### DIFF
--- a/erd.html
+++ b/erd.html
@@ -157,6 +157,10 @@
       'toolbar.templates.group':{ ar:'القوالب', en:'Templates' },
       'toolbar.templates.hide':{ ar:'إخفاء القالب', en:'Hide template' },
       'toolbar.templates.show':{ ar:'عرض القالب', en:'Show template' },
+      'panel.library.hide':{ ar:'إخفاء المكتبة', en:'Hide library' },
+      'panel.library.show':{ ar:'إظهار المكتبة', en:'Show library' },
+      'panel.classification.hide':{ ar:'إخفاء التصنيف', en:'Hide classification' },
+      'panel.classification.show':{ ar:'إظهار التصنيف', en:'Show classification' },
       'toolbar.ui.group':{ ar:'الواجهة', en:'Interface' },
       'toolbar.history.group':{ ar:'التاريخ', en:'History' },
       'toolbar.history.undo.title':{ ar:'تراجع', en:'Undo' },
@@ -2279,18 +2283,49 @@
 
     function ensureCanvasPointerHandlers(host){
       if(!host || host.__mishkahPointerHandlersAttached) return;
-      const setGrabbing = event => {
-        if(event && typeof event.buttons === 'number' && event.buttons !== 1) return;
+      const startPan = event => {
+        if(!event || (typeof event.buttons === 'number' && event.buttons !== 1) || event.button !== 0) return;
+        const state = {
+          pointerId: event.pointerId,
+          x: event.clientX,
+          y: event.clientY,
+          scrollLeft: host.scrollLeft,
+          scrollTop: host.scrollTop
+        };
+        host.__mishkahPanState = state;
         host.setAttribute('data-panning', 'true');
+        if(typeof host.setPointerCapture === 'function'){
+          try { host.setPointerCapture(event.pointerId); }
+          catch(error){ /* noop */ }
+        }
+        if(typeof event.preventDefault === 'function') event.preventDefault();
       };
-      const clearGrabbing = () => {
+      const movePan = event => {
+        const state = host.__mishkahPanState;
+        if(!state || typeof event.clientX !== 'number' || typeof event.clientY !== 'number') return;
+        const dx = event.clientX - state.x;
+        const dy = event.clientY - state.y;
+        host.scrollLeft = state.scrollLeft - dx;
+        host.scrollTop = state.scrollTop - dy;
+      };
+      const endPan = event => {
+        const state = host.__mishkahPanState;
+        if(state && typeof host.releasePointerCapture === 'function'){
+          try { host.releasePointerCapture(state.pointerId); }
+          catch(error){ /* noop */ }
+        }
+        host.__mishkahPanState = null;
         host.removeAttribute('data-panning');
+        if(event && typeof event.type === 'string' && event.type === 'pointercancel'){
+          if(typeof event.preventDefault === 'function') event.preventDefault();
+        }
       };
-      host.addEventListener('pointerdown', setGrabbing);
-      host.addEventListener('pointerup', clearGrabbing);
-      host.addEventListener('pointerleave', clearGrabbing);
-      host.addEventListener('pointercancel', clearGrabbing);
-      host.addEventListener('pointerout', clearGrabbing);
+      host.addEventListener('pointerdown', startPan);
+      host.addEventListener('pointermove', movePan);
+      host.addEventListener('pointerup', endPan);
+      host.addEventListener('pointerleave', endPan);
+      host.addEventListener('pointercancel', endPan);
+      host.addEventListener('pointerout', endPan);
       host.__mishkahPointerHandlersAttached = true;
     }
 
@@ -2806,6 +2841,7 @@
       ui:{
         modals:{ import:false, exportJson:false, exportSql:false, table:false, field:false, relation:false, schemaMeta:false, columns:false, classification:false },
         template:{ open:true },
+        panels:{ libraryOpen:true, classificationOpen:true },
         form:{
           table:{ name:'', nameInput:'', label:'', comment:'', includeId:true, classCode:'' },
           field:{
@@ -3148,6 +3184,8 @@
 
     function SchemaLibraryPanel(db){
       const t = createTranslator(db);
+      const panels = db.ui?.panels || {};
+      if(panels.libraryOpen === false) return null;
       const library = db.data.library || {};
       const items = library.items || [];
       const activeId = db.data.schemaId;
@@ -3167,9 +3205,12 @@
             ])))
         : D.Text.Span({ attrs:{ class: tw`text-sm text-[var(--muted)]` }}, [t('library.empty', 'لم يتم حفظ أي مخططات بعد.')]);
       return D.Containers.Aside({ attrs:{ class: tw`hidden lg:flex h-full w-72 flex-shrink-0 flex-col border-l border-[var(--border)] bg-[var(--surface-2)]/70 backdrop-blur` }}, [
-        D.Containers.Div({ attrs:{ class: tw`flex items-center justify-between px-4 py-3 border-b border-[var(--border)]` }}, [
-          D.Text.Span({ attrs:{ class: tw`text-base font-semibold` }}, [t('library.title', 'مكتبة المخططات')]),
-          D.Text.Span({ attrs:{ class: tw`text-[10px] uppercase tracking-wide text-[var(--muted)]` }}, [library.status === 'indexeddb' ? t('library.storage.indexeddb', 'IndexedDB') : t('library.storage.memory', 'ذاكرة مؤقتة')])
+        D.Containers.Div({ attrs:{ class: tw`flex items-center justify-between gap-2 px-4 py-3 border-b border-[var(--border)]` }}, [
+          D.Containers.Div({ attrs:{ class: tw`flex flex-col` }}, [
+            D.Text.Span({ attrs:{ class: tw`text-base font-semibold` }}, [t('library.title', 'مكتبة المخططات')]),
+            D.Text.Span({ attrs:{ class: tw`text-[10px] uppercase tracking-wide text-[var(--muted)]` }}, [library.status === 'indexeddb' ? t('library.storage.indexeddb', 'IndexedDB') : t('library.storage.memory', 'ذاكرة مؤقتة')])
+          ]),
+          UI.Button({ attrs:{ gkey:'erd:panel:library:toggle', 'data-state':'open', title:t('panel.library.hide', 'إخفاء المكتبة'), class: tw`!px-2 !py-1` }, variant:'ghost', size:'xs' }, [`⟵ ${t('panel.library.hide', 'إخفاء المكتبة')}`])
         ]),
         D.Containers.Div({ attrs:{ class: tw`px-4 py-3 flex flex-col gap-2` }}, [
           UI.Button({ attrs:{ gkey:'erd:library:new' }, variant:'solid', size:'sm' }, [`➕ ${t('library.new.button', 'مخطط جديد')}`]),
@@ -3181,6 +3222,8 @@
 
     function SchemaClassificationPanel(db){
       const t = createTranslator(db);
+      const panels = db.ui?.panels || {};
+      if(panels.classificationOpen === false) return null;
       const form = db.ui?.form?.classification || {};
       const rows = Array.isArray(form.rows) ? form.rows : [];
       const emptyState = rows.length === 0
@@ -3205,11 +3248,30 @@
         UI.Button({ attrs:{ gkey:'erd:classes:open-bulk' }, variant:'ghost', size:'sm' }, [`📝 ${t('classification.bulk', 'ترميز الشجرة')}`])
       ]);
       return D.Containers.Aside({ attrs:{ class: tw`hidden xl:flex h-full w-80 flex-shrink-0 flex-col border-r border-[var(--border)] bg-[var(--surface-2)]/70 backdrop-blur` }}, [
-        D.Containers.Div({ attrs:{ class: tw`flex items-center justify-between px-4 py-3 border-b border-[var(--border)]` }}, [
-          D.Text.Span({ attrs:{ class: tw`text-base font-semibold` }}, [t('classification.title', 'sche_Tree')])
+        D.Containers.Div({ attrs:{ class: tw`flex items-center justify-between gap-2 px-4 py-3 border-b border-[var(--border)]` }}, [
+          D.Text.Span({ attrs:{ class: tw`text-base font-semibold` }}, [t('classification.title', 'sche_Tree')]),
+          UI.Button({ attrs:{ gkey:'erd:panel:classification:toggle', 'data-state':'open', title:t('panel.classification.hide', 'إخفاء التصنيف'), class: tw`!px-2 !py-1` }, variant:'ghost', size:'xs' }, [`${t('panel.classification.hide', 'إخفاء التصنيف')} ⟶`])
         ]),
         D.Containers.Div({ attrs:{ class: tw`px-4 py-3 flex flex-col gap-3` }}, [actions]),
         D.Containers.Div({ attrs:{ class: tw`flex-1 overflow-y-auto px-4 pb-4 flex flex-col gap-3` }}, content)
+      ]);
+    }
+
+    function CollapsedPanelReveal(db, side){
+      const t = createTranslator(db);
+      const labelKey = side === 'left' ? 'panel.library.show' : 'panel.classification.show';
+      const fallback = side === 'left' ? 'إظهار المكتبة' : 'إظهار التصنيف';
+      const label = t(labelKey, fallback);
+      const gkey = side === 'left' ? 'erd:panel:library:toggle' : 'erd:panel:classification:toggle';
+      const icon = side === 'left' ? '⟶' : '⟵';
+      const baseClass = tw`absolute top-4`;
+      const containerClass = `${baseClass} ${side === 'left' ? 'left-4' : 'right-4'}`;
+      return D.Containers.Div({ attrs:{ class: tw`pointer-events-none` }}, [
+        D.Containers.Div({ attrs:{ class: containerClass }}, [
+          UI.Button({ attrs:{ gkey, 'data-state':'closed', class: tw`pointer-events-auto !px-3 !py-2 rounded-full border border-[var(--border)] bg-[var(--surface-1)]/95 shadow-lg backdrop-blur`, title: label }, variant:'soft', size:'sm' }, [
+            side === 'left' ? `${icon} ${label}` : `${label} ${icon}`
+          ])
+        ])
       ]);
     }
 
@@ -3288,10 +3350,6 @@
         D.Text.Span({ attrs:{ class: tw`text-sm font-semibold` }}, [t('toolbar.export', 'تصدير')]),
         D.Text.Span({ attrs:{ class: tw`text-xs opacity-70` }}, ['⯆'])
       ]);
-      const button = D.Containers.Div({ attrs:{ class: tw`relative overflow-visible`, style:'z-index:2147482000;' }}, [toggle]);
-      if(!open){
-        return { button, overlay:null };
-      }
       const formats = [
         { id:'sql:postgres', label:'SQL — Postgres', format:'sql', dialect:'postgres' },
         { id:'sql:mysql', label:'SQL — MySQL', format:'sql', dialect:'mysql' },
@@ -3315,42 +3373,24 @@
           }, [item.label])
         ])
       ));
-      const anchor = db.ui?.toolbar?.exportAnchor || null;
       const dir = (db.env?.dir || db.env?.direction || 'rtl').toLowerCase();
-      const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : 0;
-      const viewportHeight = typeof window !== 'undefined' ? window.innerHeight : 0;
-      const estimatedWidth = 260;
-      const estimatedHeight = 320;
-      const margin = 12;
-      let left = margin;
-      let top = margin + 56;
-      if(anchor){
-        if(dir === 'rtl'){
-          left = anchor.right - estimatedWidth;
-          if(left < margin){
-            left = Math.max(margin, anchor.x - estimatedWidth + anchor.width);
-          }
-        } else {
-          left = anchor.x;
-        }
-        if(viewportWidth){
-          const maxLeft = Math.max(margin, viewportWidth - estimatedWidth - margin);
-          if(left > maxLeft) left = maxLeft;
-          if(left < margin) left = margin;
-        }
-        top = anchor.bottom + margin;
-        if(viewportHeight){
-          const maxTop = Math.max(margin, viewportHeight - estimatedHeight - margin);
-          if(top > maxTop) top = maxTop;
-          if(top < margin) top = margin;
-        }
+      const baseMenuClass = tw`absolute top-full mt-3`;
+      const menuPosition = dir === 'rtl' ? 'right-0' : 'left-0';
+      const menuClass = `${baseMenuClass} ${menuPosition}`;
+      const buttonChildren = open
+        ? [
+            toggle,
+            D.Containers.Div({ attrs:{ class: menuClass }}, [
+              D.Containers.Div({ attrs:{ id:'erd-toolbar-export-menu', class: tw`min-w-[240px] rounded-2xl border border-[var(--border)] bg-[var(--surface-1)]/95 shadow-xl backdrop-blur-md pointer-events-auto` }}, [list])
+            ])
+          ]
+        : [toggle];
+      const button = D.Containers.Div({ attrs:{ class: tw`relative overflow-visible`, style:'z-index:2147482000;' }}, buttonChildren);
+      if(!open){
+        return { button, overlay:null };
       }
-      const menuStyle = `left:${Math.round(left)}px;top:${Math.round(top)}px;`;
       const overlay = D.Containers.Div({ attrs:{ class: tw`absolute inset-0 pointer-events-none` }}, [
-        D.Containers.Div({ attrs:{ class: tw`absolute inset-0 pointer-events-auto`, gkey:'erd:toolbar:export:close' }}, []),
-        D.Containers.Div({ attrs:{ class: tw`absolute pointer-events-auto`, style: menuStyle }}, [
-          D.Containers.Div({ attrs:{ id:'erd-toolbar-export-menu', class: tw`min-w-[240px] rounded-2xl border border-[var(--border)] bg-[var(--surface-1)]/95 shadow-xl backdrop-blur-md pointer-events-auto` }}, [list])
-        ])
+        D.Containers.Div({ attrs:{ class: tw`absolute inset-0 pointer-events-auto`, gkey:'erd:toolbar:export:close' }}, [])
       ]);
       return { button, overlay };
     }
@@ -4042,6 +4082,14 @@
       const toolbarResult = Toolbar(db);
       const toolbarView = toolbarResult && toolbarResult.view ? toolbarResult.view : toolbarResult;
       const toolbarOverlays = (toolbarResult && Array.isArray(toolbarResult.overlays) ? toolbarResult.overlays : []).filter(Boolean);
+      const panels = db.ui?.panels || {};
+      const libraryOpen = panels.libraryOpen !== false;
+      const classificationOpen = panels.classificationOpen !== false;
+      const libraryPanel = libraryOpen ? SchemaLibraryPanel(db) : null;
+      const classificationPanel = classificationOpen ? SchemaClassificationPanel(db) : null;
+      const collapsedButtons = [];
+      if(!libraryOpen) collapsedButtons.push(CollapsedPanelReveal(db, 'left'));
+      if(!classificationOpen) collapsedButtons.push(CollapsedPanelReveal(db, 'right'));
       const overlayNodes = [
         ...toolbarOverlays,
         ContextMenu(db),
@@ -4051,12 +4099,13 @@
       return D.Containers.Div({ attrs:{ class: tw`flex h-screen w-full flex-col bg-[var(--surface-0)] text-[var(--foreground)]` }}, [
         toolbarView,
         D.Containers.Div({ attrs:{ class: tw`flex flex-1 min-h-0 w-full` }}, [
-          SchemaLibraryPanel(db),
-          D.Containers.Div({ attrs:{ class: tw`flex flex-1 flex-col min-h-0` }}, [
-            SchemaCanvas(db)
-          ]),
-          SchemaClassificationPanel(db)
-        ]),
+          libraryPanel,
+          D.Containers.Div({ attrs:{ class: tw`relative flex flex-1 flex-col min-h-0` }}, [
+            SchemaCanvas(db),
+            ...collapsedButtons
+          ].filter(Boolean)),
+          classificationPanel
+        ].filter(Boolean)),
         overlayRoot
       ].filter(Boolean));
     }
@@ -4202,19 +4251,6 @@
         on:['click'],
         gkeys:['erd:toolbar:export'],
         handler:(e,ctx)=>{
-          const target = e.currentTarget || e.target;
-          let anchor = null;
-          if(target && typeof target.getBoundingClientRect === 'function'){
-            const rect = target.getBoundingClientRect();
-            anchor = {
-              x: rect.left,
-              y: rect.top,
-              width: rect.width,
-              height: rect.height,
-              right: rect.right,
-              bottom: rect.bottom
-            };
-          }
           ctx.setState(s=>({
             ...s,
             ui:{
@@ -4222,7 +4258,7 @@
               toolbar:{
                 ...(s.ui?.toolbar || {}),
                 exportOpen: !(s.ui?.toolbar?.exportOpen),
-                exportAnchor: !(s.ui?.toolbar?.exportOpen) ? anchor : null
+                exportAnchor: null
               }
             }
           }));
@@ -4413,29 +4449,65 @@
           ctx.rebuild();
         }
       },
-      'erd.template.toggle':{
-        on:['click'],
-        gkeys:['erd:template:toggle'],
-        handler:(e,ctx)=>{
-          ctx.setState(s=>{
-            const currentOpen = s.ui?.template?.open !== false;
-            const nextOpen = !currentOpen;
-            return {
-              ...s,
-              ui:{
-                ...(s.ui || {}),
-                template:{ ...(s.ui?.template || {}), open: nextOpen }
-              }
-            };
-          });
-          ctx.rebuild();
-        }
-      },
-      'erd.form.update':{
-        on:['input','change'],
-        gkeys:['erd:form:update'],
-        handler:(e,ctx)=>{
-          const input = e.target;
+        'erd.template.toggle':{
+          on:['click'],
+          gkeys:['erd:template:toggle'],
+          handler:(e,ctx)=>{
+            ctx.setState(s=>{
+              const currentOpen = s.ui?.template?.open !== false;
+              const nextOpen = !currentOpen;
+              return {
+                ...s,
+                ui:{
+                  ...(s.ui || {}),
+                  template:{ ...(s.ui?.template || {}), open: nextOpen }
+                }
+              };
+            });
+            ctx.rebuild();
+          }
+        },
+        'erd.panel.library.toggle':{
+          on:['click'],
+          gkeys:['erd:panel:library:toggle'],
+          handler:(e,ctx)=>{
+            ctx.setState(s=>{
+              const currentOpen = s.ui?.panels?.libraryOpen !== false;
+              const nextOpen = !currentOpen;
+              return {
+                ...s,
+                ui:{
+                  ...(s.ui || {}),
+                  panels:{ ...(s.ui?.panels || {}), libraryOpen: nextOpen }
+                }
+              };
+            });
+            ctx.rebuild();
+          }
+        },
+        'erd.panel.classification.toggle':{
+          on:['click'],
+          gkeys:['erd:panel:classification:toggle'],
+          handler:(e,ctx)=>{
+            ctx.setState(s=>{
+              const currentOpen = s.ui?.panels?.classificationOpen !== false;
+              const nextOpen = !currentOpen;
+              return {
+                ...s,
+                ui:{
+                  ...(s.ui || {}),
+                  panels:{ ...(s.ui?.panels || {}), classificationOpen: nextOpen }
+                }
+              };
+            });
+            ctx.rebuild();
+          }
+        },
+        'erd.form.update':{
+          on:['input','change'],
+          gkeys:['erd:form:update'],
+          handler:(e,ctx)=>{
+            const input = e.target;
           const formKey = input.getAttribute('data-form');
           const fieldKey = input.getAttribute('data-field');
           const parent = input.getAttribute('data-parent');


### PR DESCRIPTION
## Summary
- add hide/show controls for the ERD library and classification sidebars with floating reopen buttons
- keep the export dropdown anchored to the toolbar button for consistent placement
- enable mouse drag panning on the ERD canvas for smoother navigation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5f55eea78833397afd3a0ce4c6527