### PR TITLE
Fix template selector placement and theme sync across templates

### DIFF
--- a/mishkah.pages.js
+++ b/mishkah.pages.js
@@ -571,9 +571,21 @@
         const defaults = applyDefaults(nextId, state);
         const pages = defaults || state.data?.pages || [];
         const active = defaults && defaults.length ? (defaults[0]?.key || null) : state.data?.active || null;
+        const prevUi = ensureDict(state.ui);
+        const prevShell = ensureDict(prevUi.pagesShell);
+        const prevMenus = ensureDict(prevShell.headerMenus);
         return Object.assign({}, state, {
           env: Object.assign({}, state.env || {}, { template: nextId }),
-          data: Object.assign({}, state.data || {}, { pages, active })
+          data: Object.assign({}, state.data || {}, { pages, active }),
+          ui: Object.assign({}, prevUi, {
+            pagesShell: Object.assign({}, prevShell, {
+              headerMenus: Object.assign({}, prevMenus, {
+                templateOpen: false,
+                langOpen: false,
+                themeOpen: false
+              })
+            })
+          })
         });
       });
       ctx.rebuild();

--- a/template/pages-helpers.js
+++ b/template/pages-helpers.js
@@ -13,6 +13,33 @@
   const ensureDict = (value) => (value && typeof value === 'object' && !Array.isArray(value) ? value : {});
   const ensureArray = (value) => (Array.isArray(value) ? value : []);
 
+  const DEFAULT_LANG_OPTIONS = [
+    { code: 'ar', label: { ar: 'العربية', en: 'Arabic' } },
+    { code: 'en', label: { ar: 'الإنجليزية', en: 'English' } }
+  ];
+
+  const LANGUAGE_DECOR = {
+    ar: { emoji: '🕌', short: 'AR' },
+    en: { emoji: '🌍', short: 'EN' }
+  };
+
+  const THEME_DECOR = {
+    'modern-dark': { emoji: '🌌' },
+    'modern-light': { emoji: '🌅' },
+    'amber-dusk': { emoji: '🌇' },
+    'aurora-night': { emoji: '🧭' },
+    'sahara-sunrise': { emoji: '🏜️' },
+    'emerald-oasis': { emoji: '🌿' },
+    'rose-mist': { emoji: '🌸' }
+  };
+
+  const MENU_TEXT = {
+    langLabel: { ar: 'اللغة', en: 'Language' },
+    themeLabel: { ar: 'الثيم الجاهز', en: 'Theme preset' },
+    templatesLabel: { ar: 'قوالب العرض', en: 'Display templates' },
+    close: { ar: 'إغلاق القائمة', en: 'Close menu' }
+  };
+
   function localizeEntry(entry, lang, fallback) {
     if (!entry) return '';
     if (typeof entry === 'string') return entry;
@@ -35,39 +62,277 @@
 
     const lang = db?.env?.lang || db?.i18n?.lang || 'ar';
     const fallbackLang = lang === 'ar' ? 'en' : 'ar';
-    const theme = db?.env?.theme || 'light';
-    const currentTemplate = db?.env?.template || 'PagesShell';
 
-    const templates = listTemplateDefs(db);
-    const templateButtons = templates.map((tpl, idx) => {
+    const setTheme = typeof twApi.setTheme === 'function' ? twApi.setTheme : null;
+    if (setTheme) {
+      const nextThemeMode = db?.env?.theme === 'dark' ? 'dark' : 'light';
+      setTheme(nextThemeMode);
+    }
+
+    const shell = Templates && Templates.PagesShell;
+    if (shell && typeof shell.applyThemeOverrides === 'function') {
+      const overrides = ensureDict(db?.data?.themeOverrides);
+      shell.applyThemeOverrides(overrides);
+    }
+
+    const templateDefs = listTemplateDefs(db);
+    const templateOptions = templateDefs.map((tpl, idx) => {
       const id = tpl.id || tpl.name || `tpl-${idx}`;
       const label = localizeEntry(tpl.label, lang, fallbackLang) || tpl.title || id;
-      const icon = tpl.icon || '🧩';
-      const isActive = id === currentTemplate;
-      return UI.Button({
-        attrs: {
-          gkey: 'ui:template:set',
-          'data-template': id,
-          title: label,
-          'aria-pressed': isActive ? 'true' : 'false',
-          class: tw`h-11 w-11 rounded-full`
-        },
-        variant: isActive ? 'solid' : 'ghost',
-        size: 'sm'
-      }, [icon]);
+      return { value: id, label, emoji: tpl.icon || '🧩' };
     }).filter(Boolean);
+    const currentTemplate = db?.env?.template || (templateOptions[0]?.value || 'PagesShell');
+    const activeTemplate = templateOptions.find((option) => option.value === currentTemplate) || templateOptions[0] || null;
 
-    const templateGroup = templateButtons.length > 1
-      ? D.Containers.Div({ attrs: { class: tw`flex items-center gap-2` } }, templateButtons)
+    const languageSource = ensureArray(db?.data?.languages);
+    const languages = (languageSource.length ? languageSource : DEFAULT_LANG_OPTIONS).map((entry, idx) => {
+      if (typeof entry === 'string') {
+        return { value: entry, label: localizeEntry({ ar: entry, en: entry }, lang, fallbackLang), emoji: '🌐', short: entry.toUpperCase() };
+      }
+      const base = ensureDict(entry);
+      const code = typeof base.code === 'string'
+        ? base.code
+        : (typeof base.value === 'string' ? base.value : `lang-${idx}`);
+      if (!code) return null;
+      const label = localizeEntry(base.label, lang, fallbackLang) || code;
+      const decor = LANGUAGE_DECOR[code] || {};
+      const emoji = decor.emoji || '🌐';
+      const short = decor.short || code.toUpperCase();
+      return { value: code, label, emoji, short };
+    }).filter(Boolean);
+    const activeLang = languages.find((entry) => entry.value === lang) || languages[0] || null;
+
+    const themePresets = ensureArray(db?.data?.themePresets);
+    let themeOptions = themePresets.map((preset, idx) => {
+      const key = typeof preset.key === 'string' ? preset.key : `theme-${idx}`;
+      if (!key) return null;
+      const label = localizeEntry(preset.label, lang, fallbackLang) || key;
+      const mode = preset.mode === 'dark' ? 'dark' : 'light';
+      const badge = mode === 'dark' ? (lang === 'ar' ? 'ليل' : 'Dark') : (lang === 'ar' ? 'نهار' : 'Light');
+      const decor = THEME_DECOR[key] || {};
+      const emoji = decor.emoji || (mode === 'dark' ? '🌙' : '🌞');
+      return { value: key, label, emoji, badge, mode };
+    }).filter(Boolean);
+    if (!themeOptions.length) {
+      themeOptions = [
+        { value: 'light', label: localizeEntry({ ar: 'ثيم فاتح', en: 'Light theme' }, lang, fallbackLang), emoji: '🌞', badge: lang === 'ar' ? 'نهار' : 'Light', mode: 'light' },
+        { value: 'dark', label: localizeEntry({ ar: 'ثيم داكن', en: 'Dark theme' }, lang, fallbackLang), emoji: '🌙', badge: lang === 'ar' ? 'ليل' : 'Dark', mode: 'dark' }
+      ];
+    }
+    const activeThemeKey = db?.data?.activeThemePreset || themeOptions[0]?.value || '';
+    const activeTheme = themeOptions.find((option) => option.value === activeThemeKey) || themeOptions[0] || null;
+
+    const uiState = ensureDict(db?.ui);
+    const shellUi = ensureDict(uiState.pagesShell);
+    const menuState = ensureDict(shellUi.headerMenus);
+    const langOpen = !!menuState.langOpen;
+    const themeOpen = !!menuState.themeOpen;
+    const templateOpen = !!menuState.templateOpen;
+
+    const triggerBaseClass = tw`flex h-11 items-center gap-2 rounded-full border border-[color-mix(in_oklab,var(--border)55%,transparent)] bg-[color-mix(in_oklab,var(--surface-1)88%,transparent)] px-4 text-sm font-semibold text-[color-mix(in_oklab,var(--foreground)92%,transparent)] shadow-[0_16px_36px_-26px_rgba(15,23,42,0.45)] transition-all duration-200 ease-out hover:-translate-y-0.5 hover:shadow-[0_24px_48px_-30px_rgba(79,70,229,0.55)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color-mix(in_oklab,var(--accent)65%,transparent)]`;
+    const triggerActiveClass = tw`border-[color-mix(in_oklab,var(--accent)55%,transparent)] shadow-[0_24px_48px_-28px_rgba(79,70,229,0.55)]`;
+    const triggerIconClass = tw`text-xl leading-none`;
+    const triggerLabelClass = tw`text-xs font-semibold leading-tight text-[color-mix(in_oklab,var(--foreground)82%,transparent)]`;
+    const triggerMetaClass = tw`text-[0.65rem] uppercase tracking-[0.35em] text-[color-mix(in_oklab,var(--muted-foreground)80%,transparent)]`;
+    const panelBaseClass = tw`absolute end-0 z-50 mt-3 w-64 origin-top-right rounded-3xl border border-[color-mix(in_oklab,var(--border)60%,transparent)] bg-[color-mix(in_oklab,var(--surface-1)92%,transparent)] p-3 shadow-[0_28px_64px_-30px_rgba(15,23,42,0.45)] backdrop-blur-xl transition-all duration-200 transform`;
+    const panelOpenClass = tw`pointer-events-auto scale-100 opacity-100 translate-y-0`;
+    const panelClosedClass = tw`pointer-events-none scale-95 opacity-0 translate-y-1.5`;
+    const closeButtonClass = tw`inline-flex h-8 w-8 items-center justify-center rounded-full border border-[color-mix(in_oklab,var(--border)60%,transparent)] text-sm font-semibold text-[color-mix(in_oklab,var(--muted-foreground)80%,transparent)] transition hover:bg-[color-mix(in_oklab,var(--surface-2)85%,transparent)] hover:text-[color-mix(in_oklab,var(--foreground)90%,transparent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color-mix(in_oklab,var(--accent)60%,transparent)]`;
+    const optionBaseClass = tw`flex w-full items-center gap-3 rounded-2xl px-3 py-2 text-sm transition-colors duration-150 ease-out focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]`;
+    const optionActiveClass = tw`bg-[var(--primary)] text-[var(--primary-foreground)] shadow-[0_18px_38px_-22px_rgba(79,70,229,0.55)]`;
+    const optionInactiveClass = tw`text-[color-mix(in_oklab,var(--foreground)78%,transparent)] hover:bg-[color-mix(in_oklab,var(--surface-2)85%,transparent)]`;
+
+    const langLabel = localizeEntry(MENU_TEXT.langLabel, lang, fallbackLang) || '';
+    const themeLabel = localizeEntry(MENU_TEXT.themeLabel, lang, fallbackLang) || '';
+    const templatesLabel = localizeEntry(MENU_TEXT.templatesLabel, lang, fallbackLang) || '';
+    const closeLabel = localizeEntry(MENU_TEXT.close, lang, fallbackLang) || '';
+
+    const langMenu = languages.length
+      ? D.Containers.Div({
+          attrs: {
+            class: tw`relative inline-flex`,
+            'data-menu-container': 'lang'
+          }
+        }, [
+          D.Forms.Button({
+            attrs: {
+              type: 'button',
+              class: cx(triggerBaseClass, langOpen ? triggerActiveClass : ''),
+              title: langLabel,
+              'aria-haspopup': 'listbox',
+              'aria-expanded': langOpen ? 'true' : 'false',
+              'data-menu-toggle': 'lang',
+              gkey: 'ui:header:menuToggle'
+            }
+          }, [
+            D.Text.Span({ attrs: { class: triggerIconClass } }, [activeLang ? activeLang.emoji : '🌐']),
+            D.Containers.Div({ attrs: { class: tw`flex flex-col text-start` } }, [
+              D.Text.Span({ attrs: { class: triggerLabelClass } }, [activeLang ? activeLang.label : langLabel]),
+              D.Text.Span({ attrs: { class: triggerMetaClass } }, [activeLang ? activeLang.short : lang.toUpperCase()])
+            ])
+          ]),
+          D.Containers.Div({
+            attrs: {
+              class: cx(panelBaseClass, langOpen ? panelOpenClass : panelClosedClass),
+              'data-menu-panel': 'lang'
+            }
+          }, [
+            D.Containers.Div({ attrs: { class: tw`flex items-center justify-between gap-2 px-2` } }, [
+              D.Text.Span({ attrs: { class: tw`text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-[var(--muted-foreground)]` } }, [langLabel]),
+              D.Forms.Button({
+                attrs: {
+                  type: 'button',
+                  class: closeButtonClass,
+                  gkey: 'ui:header:menuClose',
+                  'data-menu-close': 'lang',
+                  'aria-label': closeLabel
+                }
+              }, ['✕'])
+            ]),
+            D.Containers.Div({ attrs: { class: tw`mt-3 grid gap-1.5` } }, languages.map((option) => D.Forms.Button({
+              attrs: {
+                type: 'button',
+                gkey: 'ui:lang:select',
+                'data-lang-select': 'true',
+                'data-lang-value': option.value,
+                value: option.value,
+                class: cx(optionBaseClass, option.value === lang ? optionActiveClass : optionInactiveClass)
+              }
+            }, [
+              D.Text.Span({ attrs: { class: tw`text-lg leading-none` } }, [option.emoji]),
+              D.Containers.Div({ attrs: { class: tw`flex flex-col text-start` } }, [
+                D.Text.Span({ attrs: { class: tw`font-semibold` } }, [option.label]),
+                D.Text.Span({ attrs: { class: triggerMetaClass } }, [option.short])
+              ])
+            ])))
+          ])
+        ])
       : null;
 
-    const themeToggle = typeof UI.ThemeToggleIcon === 'function'
-      ? UI.ThemeToggleIcon({ theme, attrs: { class: tw`h-11 w-11` } })
+    const themeMenu = themeOptions.length
+      ? D.Containers.Div({
+          attrs: {
+            class: tw`relative inline-flex`,
+            'data-menu-container': 'theme'
+          }
+        }, [
+          D.Forms.Button({
+            attrs: {
+              type: 'button',
+              class: cx(triggerBaseClass, themeOpen ? triggerActiveClass : ''),
+              title: themeLabel,
+              'aria-haspopup': 'listbox',
+              'aria-expanded': themeOpen ? 'true' : 'false',
+              'data-menu-toggle': 'theme',
+              gkey: 'ui:header:menuToggle'
+            }
+          }, [
+            D.Text.Span({ attrs: { class: triggerIconClass } }, [activeTheme ? activeTheme.emoji : '🎨']),
+            D.Containers.Div({ attrs: { class: tw`flex flex-col text-start` } }, [
+              D.Text.Span({ attrs: { class: triggerLabelClass } }, [activeTheme ? activeTheme.label : themeLabel]),
+              activeTheme ? D.Text.Span({ attrs: { class: triggerMetaClass } }, [activeTheme.badge]) : null
+            ].filter(Boolean))
+          ]),
+          D.Containers.Div({
+            attrs: {
+              class: cx(panelBaseClass, themeOpen ? panelOpenClass : panelClosedClass),
+              'data-menu-panel': 'theme'
+            }
+          }, [
+            D.Containers.Div({ attrs: { class: tw`flex items-center justify-between gap-2 px-2` } }, [
+              D.Text.Span({ attrs: { class: tw`text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-[var(--muted-foreground)]` } }, [themeLabel]),
+              D.Forms.Button({
+                attrs: {
+                  type: 'button',
+                  class: closeButtonClass,
+                  gkey: 'ui:header:menuClose',
+                  'data-menu-close': 'theme',
+                  'aria-label': closeLabel
+                }
+              }, ['✕'])
+            ]),
+            D.Containers.Div({ attrs: { class: tw`mt-3 grid gap-1.5` } }, themeOptions.map((option) => D.Forms.Button({
+              attrs: {
+                type: 'button',
+                gkey: 'ui:theme:select',
+                'data-theme-select': 'true',
+                'data-theme-value': option.value,
+                value: option.value,
+                class: cx(optionBaseClass, option.value === activeThemeKey ? optionActiveClass : optionInactiveClass)
+              }
+            }, [
+              D.Text.Span({ attrs: { class: tw`text-lg leading-none` } }, [option.emoji]),
+              D.Containers.Div({ attrs: { class: tw`flex flex-col text-start` } }, [
+                D.Text.Span({ attrs: { class: tw`font-semibold` } }, [option.label]),
+                D.Text.Span({ attrs: { class: triggerMetaClass } }, [option.badge])
+              ])
+            ])))
+          ])
+        ])
       : null;
 
-    const languageSwitch = typeof UI.LanguageSwitch === 'function'
-      ? UI.LanguageSwitch({ lang })
+    const templateMenu = templateOptions.length > 1
+      ? D.Containers.Div({
+          attrs: {
+            class: tw`relative inline-flex`,
+            'data-menu-container': 'template'
+          }
+        }, [
+          D.Forms.Button({
+            attrs: {
+              type: 'button',
+              class: cx(triggerBaseClass, templateOpen ? triggerActiveClass : ''),
+              title: templatesLabel,
+              'aria-haspopup': 'listbox',
+              'aria-expanded': templateOpen ? 'true' : 'false',
+              'data-menu-toggle': 'template',
+              gkey: 'ui:header:menuToggle'
+            }
+          }, [
+            D.Text.Span({ attrs: { class: triggerIconClass } }, [activeTemplate ? activeTemplate.emoji : '🧩']),
+            D.Containers.Div({ attrs: { class: tw`flex flex-col text-start` } }, [
+              D.Text.Span({ attrs: { class: triggerLabelClass } }, [activeTemplate ? activeTemplate.label : templatesLabel]),
+              D.Text.Span({ attrs: { class: triggerMetaClass } }, [templatesLabel])
+            ])
+          ]),
+          D.Containers.Div({
+            attrs: {
+              class: cx(panelBaseClass, templateOpen ? panelOpenClass : panelClosedClass),
+              'data-menu-panel': 'template'
+            }
+          }, [
+            D.Containers.Div({ attrs: { class: tw`flex items-center justify-between gap-2 px-2` } }, [
+              D.Text.Span({ attrs: { class: tw`text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-[var(--muted-foreground)]` } }, [templatesLabel]),
+              D.Forms.Button({
+                attrs: {
+                  type: 'button',
+                  class: closeButtonClass,
+                  gkey: 'ui:header:menuClose',
+                  'data-menu-close': 'template',
+                  'aria-label': closeLabel
+                }
+              }, ['✕'])
+            ]),
+            D.Containers.Div({ attrs: { class: tw`mt-3 grid gap-1.5` } }, templateOptions.map((option) => D.Forms.Button({
+              attrs: {
+                type: 'button',
+                gkey: 'ui:template:set',
+                'data-template': option.value,
+                value: option.value,
+                class: cx(optionBaseClass, option.value === currentTemplate ? optionActiveClass : optionInactiveClass)
+              }
+            }, [
+              D.Text.Span({ attrs: { class: tw`text-lg leading-none` } }, [option.emoji]),
+              D.Containers.Div({ attrs: { class: tw`flex flex-col text-start` } }, [
+                D.Text.Span({ attrs: { class: tw`font-semibold` } }, [option.label])
+              ])
+            ])))
+          ])
+        ])
       : null;
+
+    const controls = [templateMenu, themeMenu, langMenu].filter(Boolean);
+    if (!controls.length) return null;
 
     const justifyClass = align === 'start'
       ? tw`justify-start`
@@ -76,9 +341,6 @@
         : tw`justify-end`;
 
     const directionClass = direction === 'column' ? tw`flex-col` : tw`flex-row flex-wrap`;
-
-    const controls = [templateGroup, themeToggle, languageSwitch].filter(Boolean);
-    if (!controls.length) return null;
 
     return D.Containers.Div({
       attrs: {

--- a/ui/index-ui.js
+++ b/ui/index-ui.js
@@ -1299,6 +1299,7 @@
     const themeLabOpen = !!themeLabUi.open;
     const langOpen = !!headerMenusUi.langOpen;
     const themeOpen = !!headerMenusUi.themeOpen;
+    const templateOpen = !!headerMenusUi.templateOpen;
 
     const optionBaseClass = tw`flex w-full items-center gap-3 rounded-2xl px-3 py-2 text-sm transition-colors duration-150 ease-out focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]`;
     const optionActiveClass = tw`bg-[var(--primary)] text-[var(--primary-foreground)] shadow-[0_18px_38px_-22px_rgba(79,70,229,0.55)]`;
@@ -1322,7 +1323,10 @@
         }
       }, [
         D.Text.Span({ attrs: { class: triggerIconClass } }, [activeLang ? activeLang.emoji : '🌐']),
-        D.Text.Span({ attrs: { class: triggerMetaClass } }, [activeLang ? activeLang.short : 'LANG'])
+        D.Containers.Div({ attrs: { class: tw`flex flex-col text-start` } }, [
+          D.Text.Span({ attrs: { class: triggerLabelClass } }, [activeLang ? activeLang.label : TL('header.lang.label')]),
+          D.Text.Span({ attrs: { class: triggerMetaClass } }, [activeLang ? activeLang.short : lang.toUpperCase()])
+        ])
       ]),
       D.Containers.Div({
         attrs: {
@@ -1424,6 +1428,8 @@
       ])
     ]);
 
+    let templateMenu = null;
+
     const iconCircleClass = tw`flex h-11 w-11 items-center justify-center rounded-full border border-[color-mix(in_oklab,var(--border)55%,transparent)] bg-[color-mix(in_oklab,var(--surface-1)88%,transparent)] text-xl transition-all duration-200 ease-out hover:-translate-y-0.5 hover:shadow-[0_24px_48px_-28px_rgba(79,70,229,0.55)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color-mix(in_oklab,var(--accent)65%,transparent)]`;
     const themeLabButton = UI.Button({
       attrs: {
@@ -1443,20 +1449,79 @@
     const templateFallback = M.Pages && typeof M.Pages.listTemplates === 'function' ? M.Pages.listTemplates() : [];
     const templateDefs = (templateSource.length ? templateSource : templateFallback).map((entry) => (typeof entry === 'string' ? { id: entry } : entry)).filter((entry) => entry && (entry.id || entry.name));
     const currentTemplate = db?.env?.template || (templateDefs[0] && (templateDefs[0].id || templateDefs[0].name)) || 'PagesShell';
-    const templateItems = templateDefs.map((tpl) => {
+    const templateOptions = templateDefs.map((tpl) => {
       const id = tpl.id || tpl.name || 'PagesShell';
       const labelEntry = ensureDict(tpl.label);
       const label = localize(labelEntry, lang, fallbackLang) || tpl.title || id;
-      const icon = tpl.icon || '🧩';
+      const emoji = tpl.icon || '🧩';
       return {
-        id,
-        label: `${icon ? `${icon} ` : ''}${label}`,
-        attrs: { 'data-template': id, gkey: 'ui:template:set' }
+        value: id,
+        label,
+        emoji
       };
     });
-    const templateSwitcher = templateItems.length > 1
-      ? UI.Segmented({ items: templateItems, activeId: currentTemplate, attrs: { class: tw`w-full` } })
-      : null;
+    const activeTemplate = templateOptions.find((option) => option.value === currentTemplate) || templateOptions[0] || null;
+    if (templateOptions.length > 1) {
+      templateMenu = D.Containers.Div({
+        attrs: {
+          class: tw`relative inline-flex`,
+          'data-menu-container': 'template'
+        }
+      }, [
+        D.Forms.Button({
+          attrs: {
+            type: 'button',
+            class: cx(triggerBaseClass, templateOpen ? triggerActiveClass : ''),
+            title: TL('header.templates.label'),
+            'aria-haspopup': 'listbox',
+            'aria-expanded': templateOpen ? 'true' : 'false',
+            'data-menu-toggle': 'template',
+            gkey: 'ui:header:menuToggle'
+          }
+        }, [
+          D.Text.Span({ attrs: { class: triggerIconClass } }, [activeTemplate ? activeTemplate.emoji : '🧩']),
+          D.Containers.Div({ attrs: { class: tw`flex flex-col text-start` } }, [
+            D.Text.Span({ attrs: { class: triggerLabelClass } }, [activeTemplate ? activeTemplate.label : TL('header.templates.label')]),
+            D.Text.Span({ attrs: { class: triggerMetaClass } }, [TL('header.templates.label')])
+          ])
+        ]),
+        D.Containers.Div({
+          attrs: {
+            class: cx(panelBaseClass, templateOpen ? panelOpenClass : panelClosedClass),
+            'data-menu-panel': 'template'
+          }
+        }, [
+          D.Containers.Div({ attrs: { class: tw`flex items-center justify-between gap-2 px-2` } }, [
+            D.Text.Span({ attrs: { class: tw`text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-[var(--muted-foreground)]` } }, [TL('header.templates.label')]),
+            D.Forms.Button({
+              attrs: {
+                type: 'button',
+                class: closeButtonClass,
+                gkey: 'ui:header:menuClose',
+                'data-menu-close': 'template',
+                'aria-label': TL('header.menu.close')
+              }
+            }, ['✕'])
+          ]),
+          D.Containers.Div({ attrs: { class: tw`mt-3 grid gap-1.5` } }, templateOptions.map((option) => D.Forms.Button({
+            attrs: {
+              type: 'button',
+              gkey: 'ui:template:set',
+              'data-template': option.value,
+              value: option.value,
+              class: cx(optionBaseClass, option.value === currentTemplate ? optionActiveClass : optionInactiveClass)
+            }
+          }, [
+            D.Text.Span({ attrs: { class: tw`text-lg leading-none` } }, [option.emoji]),
+            D.Containers.Div({ attrs: { class: tw`flex flex-col text-start` } }, [
+              D.Text.Span({ attrs: { class: tw`font-semibold` } }, [option.label])
+            ])
+          ])))
+        ])
+      ]);
+    }
+
+    const headerControls = [langMenu, themeMenu, templateMenu, themeLabButton].filter(Boolean);
 
     const searchState = ensureDict(data.search);
     const searchQuery = typeof searchState.query === 'string' ? searchState.query : '';
@@ -1526,7 +1591,7 @@
 
     const searchBox = D.Containers.Div({ attrs: { class: tw`relative flex-1` } }, [searchInput, clearButton, searchResultList].filter(Boolean));
 
-    const overlay = (langOpen || themeOpen)
+    const overlay = (langOpen || themeOpen || templateOpen)
       ? D.Containers.Div({
           attrs: {
             class: tw`fixed inset-0 z-20 bg-black/10 backdrop-blur-[1px]`,
@@ -1536,21 +1601,15 @@
         })
       : null;
 
-    const searchAndTemplatesRow = D.Containers.Div({
+    const searchRow = D.Containers.Div({
       attrs: { class: tw`mt-4 flex w-full flex-col gap-3 lg:flex-row lg:items-start` }
     }, [
-      D.Containers.Div({ attrs: { class: tw`flex w-full flex-col gap-2` } }, [searchBox]),
-      templateSwitcher
-        ? D.Containers.Div({ attrs: { class: tw`flex w-full flex-col gap-2 lg:w-auto lg:min-w-[220px]` } }, [
-            D.Text.Span({ attrs: { class: tw`text-xs font-semibold uppercase tracking-[0.35em] text-[var(--muted-foreground)]` } }, [TL('header.templates.label')]),
-            templateSwitcher
-          ])
-        : null
-    ].filter(Boolean));
+      D.Containers.Div({ attrs: { class: tw`flex w-full flex-col gap-2` } }, [searchBox])
+    ]);
 
     return D.Containers.Header({
       attrs: {
-        class: cx(tw`relative border-b border-[color-mix(in_oklab,var(--border)50%,transparent)]`, (langOpen || themeOpen) ? tw`z-30` : ''),
+        class: cx(tw`relative border-b border-[color-mix(in_oklab,var(--border)50%,transparent)]`, (langOpen || themeOpen || templateOpen) ? tw`z-30` : ''),
         gkey: 'ui:header:menuMaybeClose'
       }
     }, [
@@ -1573,13 +1632,15 @@
             D.Text.H1({ attrs: { class: tw`text-3xl font-bold leading-tight` } }, [TL('app.title')]),
             D.Text.P({ attrs: { class: tw`text-sm text-[var(--muted-foreground)]` } }, [TL('header.subtitle')])
           ]),
-          D.Containers.Div({
-            attrs: {
-              class: tw`flex flex-wrap items-center justify-end gap-2`
-            }
-          }, [langMenu, themeMenu, themeLabButton])
-        ]),
-        searchAndTemplatesRow
+          headerControls.length
+            ? D.Containers.Div({
+                attrs: {
+                  class: tw`flex flex-wrap items-center justify-end gap-2`
+                }
+              }, headerControls)
+            : null
+        ].filter(Boolean)),
+        searchRow
       ])
     ].filter(Boolean));
   }
@@ -2632,7 +2693,7 @@ const board = D.Containers.Div({ attrs: { class: tw`space-y-3` } }, [
       slots: ensureDict(cfg.slots),
       ui: {
         pagesShell: {
-          headerMenus: { langOpen: false, themeOpen: false },
+          headerMenus: { langOpen: false, themeOpen: false, templateOpen: false },
           themeLab: {
             showButton: false,
             open: false,
@@ -3198,7 +3259,7 @@ const board = D.Containers.Div({ attrs: { class: tw`space-y-3` } }, [
             },
             ui: Object.assign({}, prevUi, {
               pagesShell: Object.assign({}, prevShell, {
-                headerMenus: Object.assign({}, prevMenus, { langOpen: false, themeOpen: false })
+                headerMenus: Object.assign({}, prevMenus, { langOpen: false, themeOpen: false, templateOpen: false })
               })
             })
           };
@@ -3240,7 +3301,7 @@ const board = D.Containers.Div({ attrs: { class: tw`space-y-3` } }, [
             },
             ui: Object.assign({}, prevUi, {
               pagesShell: Object.assign({}, prevShell, {
-                headerMenus: Object.assign({}, prevMenus, { langOpen: false, themeOpen: false }),
+                headerMenus: Object.assign({}, prevMenus, { langOpen: false, themeOpen: false, templateOpen: false }),
                 themeLab: Object.assign({}, prevThemeLab, {
                   draft: Object.assign({}, overrides)
                 })
@@ -3266,13 +3327,20 @@ const board = D.Containers.Div({ attrs: { class: tw`space-y-3` } }, [
           const prevMenus = ensureDict(prevShell.headerMenus);
           const nextMenus = Object.assign({}, prevMenus, {
             langOpen: target === 'lang' ? !prevMenus.langOpen : false,
-            themeOpen: target === 'theme' ? !prevMenus.themeOpen : false
+            themeOpen: target === 'theme' ? !prevMenus.themeOpen : false,
+            templateOpen: target === 'template' ? !prevMenus.templateOpen : false
           });
           if (target === 'lang') {
             nextMenus.themeOpen = false;
+            nextMenus.templateOpen = false;
           }
           if (target === 'theme') {
             nextMenus.langOpen = false;
+            nextMenus.templateOpen = false;
+          }
+          if (target === 'template') {
+            nextMenus.langOpen = false;
+            nextMenus.themeOpen = false;
           }
           return {
             ...prev,
@@ -3307,6 +3375,10 @@ const board = D.Containers.Div({ attrs: { class: tw`space-y-3` } }, [
             if (nextMenus.themeOpen) changed = true;
             nextMenus.themeOpen = false;
           }
+          if (scope === 'template' || scope === 'all') {
+            if (nextMenus.templateOpen) changed = true;
+            nextMenus.templateOpen = false;
+          }
           if (!changed) return prev;
           return {
             ...prev,
@@ -3334,19 +3406,19 @@ const board = D.Containers.Div({ attrs: { class: tw`space-y-3` } }, [
         const prevUi = ensureDict(state.ui);
         const prevShell = ensureDict(prevUi.pagesShell);
         const prevMenus = ensureDict(prevShell.headerMenus);
-        if (!prevMenus.langOpen && !prevMenus.themeOpen) return;
+        if (!prevMenus.langOpen && !prevMenus.themeOpen && !prevMenus.templateOpen) return;
         let changed = false;
         context.setState((prev) => {
           const prevUiState = ensureDict(prev.ui);
           const prevShellState = ensureDict(prevUiState.pagesShell);
           const prevMenuState = ensureDict(prevShellState.headerMenus);
-          if (!prevMenuState.langOpen && !prevMenuState.themeOpen) return prev;
+          if (!prevMenuState.langOpen && !prevMenuState.themeOpen && !prevMenuState.templateOpen) return prev;
           changed = true;
           return {
             ...prev,
             ui: Object.assign({}, prevUiState, {
               pagesShell: Object.assign({}, prevShellState, {
-                headerMenus: Object.assign({}, prevMenuState, { langOpen: false, themeOpen: false })
+                headerMenus: Object.assign({}, prevMenuState, { langOpen: false, themeOpen: false, templateOpen: false })
               })
             })
           };


### PR DESCRIPTION
## Summary
- move the template selector into the primary header control row beside the language and theme menus
- keep the search row focused on search while still supporting the shared dropdown controls above it
- synchronize theme mode and custom CSS variable overrides for every template render via the shared helpers

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e612728e6483338f1e241095bfe9fe