### PR TITLE
Add optional media metadata to page templates

### DIFF
--- a/template/pages-helpers.js
+++ b/template/pages-helpers.js
@@ -13,6 +13,27 @@
   const ensureDict = (value) => (value && typeof value === 'object' && !Array.isArray(value) ? value : {});
   const ensureArray = (value) => (Array.isArray(value) ? value : []);
 
+  function ensureMediaList(list) {
+    const seen = new Set();
+    const out = [];
+    ensureArray(list).forEach((value) => {
+      if (typeof value !== 'string') return;
+      const trimmed = value.trim();
+      if (!trimmed || seen.has(trimmed)) return;
+      seen.add(trimmed);
+      out.push(trimmed);
+    });
+    return out;
+  }
+
+  function getPrimaryImage(entry) {
+    if (!entry) return null;
+    const main = typeof entry.mainImage === 'string' ? entry.mainImage.trim() : '';
+    if (main) return main;
+    const gallery = ensureMediaList(entry.images);
+    return gallery.length ? gallery[0] : null;
+  }
+
   const DEFAULT_LANG_OPTIONS = [
     { code: 'ar', label: { ar: 'العربية', en: 'Arabic' } },
     { code: 'en', label: { ar: 'الإنجليزية', en: 'English' } }
@@ -435,6 +456,8 @@
   Templates.__pagesHelpers = {
     ensureArray,
     ensureDict,
+    ensureMediaList,
+    getPrimaryImage,
     getPages,
     getClasses,
     buildClassTree,

--- a/template/pages-sdk.js
+++ b/template/pages-sdk.js
@@ -18,6 +18,76 @@
   const callPageComponent = helpers.callPageComponent || (() => null);
   const tw = helpers.tw || ((value) => value);
   const renderGlobalSwitchers = helpers.renderGlobalSwitchers || (() => null);
+  const ensureMediaList = helpers.ensureMediaList || ((list) => {
+    const seen = new Set();
+    const src = Array.isArray(list) ? list : (typeof list === 'string' ? [list] : []);
+    const out = [];
+    src.forEach((value) => {
+      if (typeof value !== 'string') return;
+      const trimmed = value.trim();
+      if (!trimmed || seen.has(trimmed)) return;
+      seen.add(trimmed);
+      out.push(trimmed);
+    });
+    return out;
+  });
+
+  function renderMediaGallery(entry, altText, variant) {
+    if (!entry) return null;
+    const mainImage = typeof entry.mainImage === 'string' ? entry.mainImage.trim() : '';
+    const mainVideo = typeof entry.mainVideo === 'string' ? entry.mainVideo.trim() : '';
+    const gallery = ensureMediaList(entry.images).filter((url) => url !== mainImage);
+    if (!mainImage && !mainVideo && !gallery.length) return null;
+
+    const mode = variant === 'compact' ? 'compact' : 'default';
+    const wrapperClass = mode === 'compact'
+      ? tw`mt-3 space-y-3`
+      : tw`mt-6 space-y-4`;
+    const heroClass = mode === 'compact'
+      ? tw`h-40 w-full overflow-hidden rounded-2xl border border-[color-mix(in_oklab,var(--border)55%,transparent)] object-cover shadow-[0_16px_36px_-24px_rgba(15,23,42,0.4)]`
+      : tw`h-64 w-full overflow-hidden rounded-3xl border border-[color-mix(in_oklab,var(--border)55%,transparent)] object-cover shadow-[0_24px_52px_-30px_rgba(15,23,42,0.5)]`;
+    const videoClass = mode === 'compact'
+      ? tw`h-40 w-full overflow-hidden rounded-2xl border border-[color-mix(in_oklab,var(--border)55%,transparent)] bg-black object-cover shadow-[0_16px_36px_-24px_rgba(15,23,42,0.4)]`
+      : tw`h-64 w-full overflow-hidden rounded-3xl border border-[color-mix(in_oklab,var(--border)55%,transparent)] bg-black object-cover shadow-[0_24px_52px_-30px_rgba(15,23,42,0.5)]`;
+    const gridClass = mode === 'compact'
+      ? tw`grid gap-2 sm:grid-cols-2`
+      : tw`grid gap-3 sm:grid-cols-2 lg:grid-cols-3`;
+    const imageClass = mode === 'compact'
+      ? tw`h-28 w-full overflow-hidden rounded-2xl border border-[color-mix(in_oklab,var(--border)55%,transparent)] object-cover`
+      : tw`h-36 w-full overflow-hidden rounded-2xl border border-[color-mix(in_oklab,var(--border)55%,transparent)] object-cover`;
+
+    const blocks = [];
+    if (mainImage) {
+      blocks.push(D.Media.Img({
+        attrs: {
+          src: mainImage,
+          alt: altText || '',
+          class: heroClass
+        }
+      }));
+    }
+    if (mainVideo) {
+      blocks.push(D.Media.Video({
+        attrs: {
+          src: mainVideo,
+          controls: true,
+          playsinline: true,
+          class: videoClass
+        }
+      }));
+    }
+    if (gallery.length) {
+      blocks.push(D.Containers.Div({ attrs: { class: gridClass } }, gallery.map((url, idx) => D.Media.Img({
+        attrs: {
+          src: url,
+          alt: altText ? `${altText} ${idx + 1}` : `Gallery item ${idx + 1}`,
+          class: imageClass
+        }
+      }))));
+    }
+
+    return blocks.length ? D.Containers.Div({ attrs: { class: wrapperClass } }, blocks) : null;
+  }
 
   function localizeText(entry, lang, fallback) {
     if (!entry) return '';
@@ -72,11 +142,13 @@
 
     const classNode = activePage.classKey && tree.map ? tree.map[activePage.classKey] : null;
     if (classNode) {
+      const classMedia = renderMediaGallery(classNode, localizeText(classNode.label, lang, fallback), 'compact');
       rows.push(D.Containers.Div({ attrs: { class: tw`rounded-2xl border border-[color-mix(in_oklab,var(--border)55%,transparent)] bg-[color-mix(in_oklab,var(--surface-1)96%,transparent)] p-4` } }, [
         D.Text.Strong({ attrs: { class: tw`text-sm text-[var(--muted-foreground)]` } }, [localizeText(classNode.label, lang, fallback)]),
         localizeText(classNode.desc, lang, fallback)
           ? D.Text.P({ attrs: { class: tw`mt-2 text-xs text-[var(--muted-foreground)]` } }, [localizeText(classNode.desc, lang, fallback)])
-          : null
+          : null,
+        classMedia
       ].filter(Boolean)));
     }
 
@@ -127,6 +199,7 @@
 
     const activeTitle = localizeText(activePage?.label, lang, fallback) || (activePage?.key || '');
     const activeBody = callPageComponent(registry, activePage, db) || UI.EmptyState?.({ icon: '📘', title: activeTitle }) || null;
+    const mediaContent = renderMediaGallery(activePage, activeTitle);
     const metaSections = buildMetaSection(activePage, lang, fallback, classTree);
 
     const contentCard = D.Containers.Section({
@@ -138,6 +211,7 @@
         D.Text.Span({ attrs: { class: tw`text-xs font-semibold uppercase tracking-[0.32em] text-[var(--muted-foreground)]` } }, [lang === 'ar' ? 'مكتبة SDK' : 'SDK Library']),
         D.Text.H1({ attrs: { class: tw`text-3xl font-bold` } }, [activeTitle])
       ]),
+      mediaContent,
       D.Containers.Div({ attrs: { class: tw`prose prose-slate max-w-none dark:prose-invert` } }, [activeBody])
     ]);
 


### PR DESCRIPTION
## Summary
- normalize optional main image, gallery, and video fields for pages and sections in the Mishkah pages builder
- expose media helper utilities for templates and propagate media metadata in the category tree
- render optional media galleries for blog and SDK page templates using the new metadata

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e62fad5f408333a4bd976e5ccfd9a5